### PR TITLE
Language QA pass

### DIFF
--- a/pages/lafires/get-help-online-shared.html
+++ b/pages/lafires/get-help-online-shared.html
@@ -463,8 +463,8 @@
         </div>
 
         <div class="bg-white brd-gray-200 brd-solid-1 rounded-10 p-a-md m-t-md">
-          <h3 class="m-t mb-2">Renter protection</h3>
-          <p><strong>Protection from eviction</strong></p>
+          <h3 class="m-t mb-2">{{ 'help_online_renter_protection_heading' | i18n }}</h3>
+          <p><strong>{{ 'help_online_renter_protection_eviction_title' | i18n }}</strong></p>
           <p>
             {{ 'help_online_renter_protection_description' | i18n | safe }}
           </p>

--- a/src/_data/i18n/i18n-stories.json
+++ b/src/_data/i18n/i18n-stories.json
@@ -1,4 +1,18 @@
 {
+  "story_99085_title": {
+    "status": "ap_review",
+    "comment": "machine_translated",
+    "src_file": "pages/lafires/",
+    "en": "Federal government approves California’s request to expand LA fire debris removal program",
+    "fr": "Le gouvernement fédéral approuve la demande de la Californie pour étendre le programme de nettoyage des débris des incendies de LA",
+    "es": "El gobierno federal aprueba la solicitud de California para expandir el programa de limpieza de desechos de incendios de LA",
+    "ko": "연방 정부가 캘리포니아의 요청을 승인하여 LA 화재 폐기물 정리 프로그램 확장",
+    "vi": "Chính phủ liên bang đã chấp thuận đề xuất của California để mở rộng chương trình làm sạch rác từ đám cháy LA",
+    "tl": "Inihayag ng federal na nag-approve ang pag-request ng California na idagdag ang programang paglilinis ng mga boto ng LA",
+    "zh-hans": "联邦政府批准加州请求扩大洛杉矶火灾垃圾清理项目",
+    "zh-hant": "聯邦政府批准加州請求擴大洛杉磯火災垃圾清理項目",
+    "hy": "Հայաստանի կառավարությունը կառավարության հրամանի միջոցով ներդաշնայությունից պաշտպանելու համար նահանգապետ Նյուսոմը նահանգային հրաման է նշանակում"
+  },
 "story_99078_title": {
     "status": "ap_review",
     "comment": "machine_translated",

--- a/src/_data/i18n/i18n-track-progress.json
+++ b/src/_data/i18n/i18n-track-progress.json
@@ -125,10 +125,18 @@
     "hy": "FEMA-ի օժանդակությամբ"
   },
   "track_progress_people_helped_lowercase": {
-    "status": "ap_not_found_in_ap_delivery",
+    "status": "ap_review",
+    "comment": "Extracted from submitted translation, converted to lowercase",
     "src_file": "pages/lafires/track-progress-shared.html",
     "en": "people helped",
-    "fr": "personnes aidées"
+    "fr": "personnes aidées",
+    "es": "personas que recibieron ayuda",
+    "ko": "사람 지원",
+    "vi": "mọi người được giúp đỡ",
+    "tl": "tumulong ang mga tao",
+    "zh-hans": "援助数据统计",
+    "zh-hant": "人們幫助",
+    "hy": "օգնություն ստացած մարդկանց քանակ"
   },
   "track_progress_distributed_to_individuals": {
     "status": "avantpage_delivery",


### PR DESCRIPTION
* Added recent newsfeed story.
* Fixed untranslated Renter Protection text on 'Get Help Online'
* Supplied untranslated 'people helped' text on 'Track Progress'