### PR TITLE
Remove /index.html and /index/ from localized links, replacing with /.

### DIFF
--- a/eleventy.config.cjs
+++ b/eleventy.config.cjs
@@ -336,7 +336,7 @@ module.exports = function (
 
   eleventyConfig.addFilter("pagePath", (page, langPath) => {
     // console.log(chalk.green(`[pagePath] Testing *${page.filePathStem}* page: ${page.url} langPath: ${langPath}`));
-    let currentPath = `${page.filePathStem}/index.html`; // Relative to base dir, localized path, with folder + /index.html.
+    let currentPath = `${page.filePathStem}/`; // Relative to base dir, localized path, with folder + /index.html.
 
     // remove /lafires/ from currentPath
     currentPath = currentPath.replace('/lafires/', '/');  
@@ -358,6 +358,8 @@ module.exports = function (
     // currentPath = currentPath.replace('/homepage/', '/');
     currentPath = currentPath.replace('/en/', '/');
     currentPath = currentPath.replace('/index/index', '/index');
+    currentPath = currentPath.replace('/index.html', '/');
+    currentPath = currentPath.replace('/index/', '/');
     // console.log(chalk.green(`  [pagePath]  output *${currentPath}*`));
     return currentPath;
   });


### PR DESCRIPTION
Replace /index.html with /
Replace /index/ with /
In localized menu links.

The effect is to remove /index.html from the language links.