### PR TITLE
Removed redundant src_file field from most i18n tables.

### DIFF
--- a/eleventy.config.cjs
+++ b/eleventy.config.cjs
@@ -8,6 +8,7 @@ const postcssNested = require("postcss-nested");
 const { DateTime } = require("luxon");
 const fs = require("node:fs");
 const path = require("node:path");
+const chalk = require("chalk");
 
 // Utility function to load all translation files and combine them
 function loadAllTranslations() {
@@ -19,11 +20,20 @@ function loadAllTranslations() {
   
   // Load and merge all translation files into a single object
   let allTranslations = {};
+  let knownKeys = [];
   translationFiles.forEach(file => {
     const filePath = path.join(translationsDir, file);
     try {
       const fileContent = fs.readFileSync(filePath, 'utf8');
       const translations = JSON.parse(fileContent);
+      // warn if any keys are duplicated
+      Object.keys(translations).forEach(key => {
+        if (knownKeys.includes(key)) {
+          console.warn(chalk.red(`[i18n] Duplicate key found in ${file}: ${key}`));
+        } else {
+          knownKeys.push(key);
+        }
+      });
       allTranslations = { ...allTranslations, ...translations };
     } catch (error) {
       console.error(`Error loading translation file ${file}:`, error);
@@ -35,7 +45,6 @@ function loadAllTranslations() {
 
 let translationsModule = loadAllTranslations();
 
-const chalk = require("chalk");
 
 // canonical domain
 const domain = "https://www.ca.gov";
@@ -384,7 +393,7 @@ module.exports = function (
 
     // Check if the requested content key exists.
     if (!contentGroup) {
-      console.log(chalk.yellow(`[i18n] Could not find content group for *${key}* in translations table.`));
+      console.log(chalk.red(`[i18n] Could not find content group for *${key}* in translations table.`));
       return "";
     }
 

--- a/src/_data/i18n/i18n-accessing.json
+++ b/src/_data/i18n/i18n-accessing.json
@@ -2,7 +2,6 @@
   "return_title": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Accessing your property",
     "fr": "Accéder à votre propriété",
     "es": "Acceder a su propiedad",
@@ -15,7 +14,6 @@
   },
   "return_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Here’s what you need to know before you return to your home.",
     "fr": "Voici ce que vous devez savoir avant de retourner à votre maison.",
     "es": "Esto es lo que necesita saber antes de regresar a su casa.",
@@ -28,7 +26,6 @@
   },
   "return_lead_text": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Here’s what you need to know before you return to your home.",
     "fr": "Voici ce que vous devez savoir avant de retourner à votre maison.",
     "es": "Esto es lo que necesita saber antes de regresar a su casa.",
@@ -41,7 +38,6 @@
   },
   "return_on_this_page": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "On this page",
     "fr": "Sur cette page",
     "es": "En esta página",
@@ -54,7 +50,6 @@
   },
   "return_damage_maps_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Fire damage maps",
     "fr": "Cartes de dommage des incendies",
     "es": "Mapas de zonas dañadas por el fuego",
@@ -67,7 +62,6 @@
   },
   "return_damage_maps_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Use damage maps from the Palisades and Eaton fires to check the status of your property.",
     "fr": "Utilisez les cartes de dommage des incendies Palisades et Eaton pour vérifier l'état de votre propriété.",
     "es": "Use los mapas de daños de los incendios de Eaton y Palisades para verificar el estado de su propiedad.",
@@ -80,7 +74,6 @@
   },
   "return_palisades_fire_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Palisades Fire",
     "fr": "Incendie Palisades",
     "es": "Incendio de Palisades",
@@ -94,7 +87,6 @@
   "return_palisades_fire_map_alt": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Palisades fire map",
     "fr": "Carte de l'incendie Palisades",
     "es": "Mapa de incendio Palisades",
@@ -108,7 +100,6 @@
   "return_view_palisades_fire_damage_map": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "View <span class='sr-only'>the Palisades Fire</span> damage map",
     "fr": "Voir la carte de dommage de l'incendie Palisades",
     "es": "Ver el mapa de daños del incendio Palisades",
@@ -121,7 +112,6 @@
   },
   "return_eaton_fire_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Eaton Fire",
     "fr": "Incendie Eaton",
     "es": "Incendio de Eaton",
@@ -135,7 +125,6 @@
   "return_eaton_fire_map_alt": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Eaton fire map",
     "fr": "Carte de l'incendie Eaton",
     "es": "Mapa de incendio Eaton",
@@ -149,7 +138,6 @@
   "return_view_eaton_fire_damage_map": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "View <span class='sr-only'>the Eaton Fire</span> damage map",
     "fr": "Voir la carte de dommage de l'incendie Eaton",
     "es": "Ver el mapa de daños del incendio Eaton",
@@ -163,7 +151,6 @@
   "return_inspection_status_intro": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Government inspectors have assessed all homes in the fire areas. On each home, you’ll see a photo and an icon with one of these statuses:",
     "fr": "Les inspecteurs du gouvernement ont évalué toutes les maisons dans les zones de feu. Sur chaque maison, vous verrez une photo et un icône avec l'un de ces statuts :",
     "es": "Los inspectores del gobierno han evaluado todas las casas en las zonas de incendio. En cada casa, verá una foto y un icono con uno de estos estados:",
@@ -176,7 +163,6 @@
   },
   "return_status_no_damage": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "No damage",
     "fr": "Aucun dommage",
     "es": "Sin daño.",
@@ -189,7 +175,6 @@
   },
   "return_status_affected": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Affected",
     "fr": "Affecté",
     "es": "Afectado.",
@@ -202,7 +187,6 @@
   },
   "return_status_minor": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Minor damage",
     "fr": "Dommage mineur",
     "es": "Daños menores.",
@@ -215,7 +199,6 @@
   },
   "return_status_major": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Major damage",
     "fr": "Dommage majeur",
     "es": "Daños mayores.",
@@ -228,7 +211,6 @@
   },
   "return_status_destroyed": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Destroyed",
     "fr": "Détruit",
     "es": "Destruido.",
@@ -241,7 +223,6 @@
   },
   "return_status_inaccessible": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Inaccessible (inspectors couldn’t access the property to check for damage)",
     "fr": "Inaccessible (les inspecteurs n'ont pas pu accéder à la propriété pour vérifier le dommage)",
     "es": "Inaccesible (los inspectores no pudieron acceder a la propiedad para verificar si había daños).",
@@ -254,7 +235,6 @@
   },
   "return_damage_photo_note": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "If your home was damaged, save a copy of the photo from the damage map. You may be able to use it when you <a href=\"/lafires/start-your-recovery/#Filing-insurance-claims\">file an insurance claim</a>.",
     "fr": "Si votre maison a été endommagée, enregistrez une copie de la photo de la carte de dommage. Vous pourriez l'utiliser lorsque vous <a href=\"/lafires/fr/start-your-recovery/#Filing-insurance-claims\">faites une réclamation d'assurance</a>.",
     "es": "Si su casa está dañada, guarde una copia de la foto del mapa de daños. Es posible que pueda usarla cuando <a href=\"/lafires/es/start-your-recovery/#Filing-insurance-claims\">presente una reclamación de seguro</a>.",
@@ -268,7 +248,6 @@
   },
   "return_neighborhood_return_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Returning to your neighborhood",
     "fr": "Retourner à votre quartier",
     "es": "Regresar a su vecindario",
@@ -281,7 +260,6 @@
   },
   "return_access_info": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "All areas are cleared for residents-only access. You may need an access pass to enter your neighborhood. You can get one in person at a <a href=\"/lafires/get-help-in-person/\">Disaster Recovery Center</a>.",
     "fr": "Toutes les zones sont libérées pour l'accès aux résidents. Vous pouvez avoir besoin d'un passeport d'accès pour entrer dans votre quartier. Vous pouvez en obtenir une en personne à un <a href=\"/lafires/fr/get-help-in-person/\">Centre de Recherche sur les Disastres</a>.",
     "es": "Todas las áreas están despejadas para el acceso exclusivo de residentes. Es posible que necesite un pase de acceso para entrar a su vecindario. Puede obtener uno en persona en un <a href=\"/lafires/es/get-help-in-person/\">centro de recuperación por catástrofes</a>",
@@ -294,7 +272,6 @@
   },
   "return_cleanup_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Getting cleanup and debris removal",
     "fr": "Nettoyage et retrait des débris après les incendies de forêt",
     "es": "Pedir limpieza y remoción de escombros",
@@ -307,7 +284,6 @@
   },
   "return_cleanup_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Cleanup and debris removal after wildfires is a 2-phase process.",
     "fr": "Le nettoyage et le retrait des débris après les incendies de forêt est un processus en 2 phases.",
     "es": "La limpieza y remoción de escombros después de los incendios es un proceso en dos fases.",
@@ -321,7 +297,6 @@
   "return_phase1_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Cleanup of hazardous waste is called Phase 1. It’s now complete.",
     "fr": "Le nettoyage des déchets dangereux est appelé Phase 1. Il est maintenant terminé.",
     "es": "La limpieza de residuos peligrosos se denomina Fase 1. Ya está completa.",
@@ -335,7 +310,6 @@
   "return_phase2_description": {
     "status": "ap_review",
     "comment": "strong tags added via machine translator",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Debris removal is Phase 2. It’s free if you in by <strong>April 15, 2025</strong>.",
     "fr": "L'enlèvement des débris est la Phase 2. C'est gratuit si vous vous inscrivez avant le <strong>15 avril 2025</strong>.",
     "es": "La remoción de escombros es la Fase 2. Es gratuita si se inscribe antes del <strong>15 de abril de 2025</strong>.",
@@ -348,7 +322,6 @@
   },
   "return_learn_about_cleanup_and_debris_removal": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Learn about cleanup and debris removal",
     "fr": "En savoir plus sur le nettoyage et le retrait des débris",
     "es": "Aprenda sobre la limpieza y remoción de escombros",
@@ -361,7 +334,6 @@
   },
   "return_more_info_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "More information",
     "fr": "Plus d'informations",
     "es": "Más información",
@@ -375,7 +347,6 @@
   "return_los_angeles_has_more_info": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/accessing-your-property-shared.html",
     "en": "Los Angeles County has more information on <a href=\"https://recovery.lacounty.gov/returning-after-fire-faq/\">preparing to return to your property after the fires</a>.",
     "fr": "Le comté de Los Angeles dispose de plus d'informations sur <a href=\"https://recovery.lacounty.gov/returning-after-fire-faq/\">la préparation au retour à votre propriété après les incendies</a>.",
     "es": "El condado de Los Ángeles tiene más información sobre <a href=\"https://recovery.lacounty.gov/returning-after-fire-faq/\">cómo prepararse para regresar a su propiedad después de los incendios</a>.",

--- a/src/_data/i18n/i18n-cleanup.json
+++ b/src/_data/i18n/i18n-cleanup.json
@@ -1,7 +1,6 @@
 {
   "cleanup_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Cleanup and debris removal",
     "fr": "Nettoyage et retrait de débris",
     "es": "Limpieza y remoción de escombros",
@@ -14,7 +13,6 @@
   },
   "cleanup_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Here we explain cleanup and debris removal phases after the LA fires. Learn how to get your property clean, safe, and cleared for rebuilding.",
     "fr": "Ici, nous expliquons les phases de nettoyage et de retrait de débris après les feux de Los Angeles. Découvrez comment nettoyer, sécuriser et débarrasser votre propriété pour la reconstruction.",
     "es": "Aquí explicamos las fases de limpieza y remoción de escombros después de los incendios de Los Ángeles (LA). Aprenda cómo lograr que su propiedad esté limpia, segura y preparada para la reconstrucción.",
@@ -27,7 +25,6 @@
   },
   "cleanup_keywords": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "California, government, LA, Los Angeles, fires, wildfires, cleanup, debris removal, Phase 1, Phase 2",
     "fr": "Californie, gouvernement, LA, Los Angeles, feux, incendies, nettoyage, retrait de débris, Phase 1, Phase 2",
     "es": "California, gobierno, LA, Los Ángeles, incendios, incendios forestales, limpieza, remoción de escombros, fase 1, fase 2",
@@ -40,7 +37,6 @@
   },
   "cleanup_cleanup_and_debris_removal_after_wildfires": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Cleanup and debris removal after wildfires is a 2-phase process. You can have it done at no cost to you.",
     "fr": "Le nettoyage et le retrait de débris après les feux de forêt sont un processus en 2 phases. Vous pouvez le faire gratuitement.",
     "es": "La limpieza y remoción de escombros después de los incendios es un proceso en dos fases. Puede solicitarlo de forma gratuita.",
@@ -53,7 +49,6 @@
   },
   "cleanup_phase_1": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Phase 1",
     "fr": "Phase 1",
     "es": "Fase 1",
@@ -66,7 +61,6 @@
   },
   "cleanup_phase_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Phase 2",
     "fr": "Phase 2",
     "es": "Fase 2",
@@ -79,7 +73,6 @@
   },
   "cleanup_hazardous_waste_cleanup": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Hazardous waste cleanup",
     "fr": "Nettoyage des déchets dangereux",
     "es": "Limpieza de residuos peligrosos",
@@ -92,7 +85,6 @@
   },
   "cleanup_debris_removal": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Debris removal",
     "fr": "Retrait de débris",
     "es": "Remoción de escombros",
@@ -106,7 +98,6 @@
   "cleanup_debris_introduction": {
     "status": "avantpage_delivery",
     "old_key": "cleanup_debris_step_p_1",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "We will explain these phases. When they are complete, your property is ready for rebuilding.",
     "fr": "Nous expliquerons ces phases. Lorsqu'elles seront terminées, votre propriété sera prête à être reconstruite.",
     "es": "Le explicaremos estas fases. Una vez que las complete, su propiedad estará lista para ser reconstruida.",
@@ -119,7 +110,6 @@
   },
   "cleanup_phase_1_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "In Phase 1, the U.S. EPA cleaned up everyday products that were in your home and could be dangerous.",
     "fr": "Dans la Phase 1, l'EPA a nettoyé les produits quotidiens qui se trouvaient dans votre maison et pouvaient être dangereux.",
     "es": "En la fase 1, la Agencia de Protección Ambiental (Environmental Protection Agency, EPA) de los Estados Unidos limpió productos de uso diario que estaban en su hogar y que podían ser peligrosos.",
@@ -133,7 +123,6 @@
   "cleanup_these_include": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "These included:",
     "fr": "Cela inclut:",
     "es": "Incluye:",
@@ -146,7 +135,6 @@
   },
   "cleanup_batteries": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Batteries",
     "fr": "Batteries",
     "es": "baterías",
@@ -159,7 +147,6 @@
   },
   "cleanup_cleaners_and_solvents": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Cleaners and solvents",
     "fr": "Produits nettoyants et solvants",
     "es": "limpiadores y solventes",
@@ -172,7 +159,6 @@
   },
   "cleanup_fertilizers_and_pesticides": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Fertilizers and pesticides",
     "fr": "Engrais et pesticides",
     "es": "fertilizantes y pesticidas",
@@ -185,7 +171,6 @@
   },
   "cleanup_paints_and_oils": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Paints and oils",
     "fr": "Peintures et huiles",
     "es": "pinturas y aceites",
@@ -198,7 +183,6 @@
   },
   "cleanup_propane_tanks_and_other_pressurized_products": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Propane tanks and other pressurized products",
     "fr": "Bouteilles de propane et autres produits sous pression",
     "es": "tanques de propano y otros productos presurizados",
@@ -211,7 +195,6 @@
   },
   "cleanup_phase_1_now_complete": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Phase 1 cleanup is now complete. It was automatic for all residential properties.",
     "fr": "Le nettoyage de la Phase 1 est maintenant terminé. Il était automatique pour toutes les propriétés résidentielles.",
     "es": "Se completó la limpieza de la fase 1. Se realizó automáticamente para todas las propiedades residenciales.",
@@ -224,7 +207,6 @@
   },
   "cleanup_no_cost_for_phase_1": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "There was no cost to you for this cleanup.",
     "fr": "Aucun coût pour vous pour ce nettoyage.",
     "es": "No hubo ningún costo para usted por este servicio de limpieza.",
@@ -237,7 +219,6 @@
   },
   "cleanup_cleanup_statuses_explained": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Cleanup statuses explained",
     "fr": "Explication des statuts de nettoyage",
     "es": "Explicación de los estados de limpieza",
@@ -250,7 +231,6 @@
   },
   "cleanup_after_the_epa_assessed_your_property": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "After the EPA assessed your property, they gave it a status.",
     "fr": "Après que l'EPA ait évalué votre propriété, elle a donné un statut.",
     "es": "Después de que la Agencia de Protección Ambiental evaluó su propiedad, se le dio un estado.",
@@ -263,7 +243,6 @@
   },
   "cleanup_they_posted_that_status_in_a_sign_on_your_property": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "They posted that status in a sign on your property.",
     "fr": "Ils ont posté ce statut sur un panneau à votre propriété.",
     "es": "Se colocó un letrero con ese estado en su propiedad.",
@@ -276,7 +255,6 @@
   },
   "cleanup_epa_map": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "You can also check this <a href=\"https://storymaps.arcgis.com/collections/13a8b227ac104bb1b1fa9592c92debe3?item=2\">EPA map</a> for the cleanup status of your property.",
     "fr": "Vous pouvez également vérifier cette <a href=\"https://storymaps.arcgis.com/collections/13a8b227ac104bb1b1fa9592c92debe3?item=2\">carte de l'EPA</a> pour le statut de nettoyage de votre propriété.",
     "es": "También puede revisar este <a href=\"https://storymaps.arcgis.com/collections/13a8b227ac104bb1b1fa9592c92debe3?item=2\">mapa de la Agencia de Protección Ambiental</a> para ver el estado de limpieza de su propiedad.",
@@ -289,7 +267,6 @@
   },
   "cleanup_phase_1_complete_status": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "This status means the EPA has finished their cleanup work.",
     "fr": "Ce statut signifie que l'EPA a terminé son travail de nettoyage.",
     "es": "Este estado significa que la Agencia de Protección Ambiental terminó su trabajo de limpieza.",
@@ -302,7 +279,6 @@
   },
   "cleanup_phase_1_complete_status_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "But your property <strong>may not be</strong> safe yet. There can still be",
     "fr": "Mais votre propriété <strong>peut ne pas être</strong> sûre encore. Il peut y avoir encore des déchets dangereux.",
     "es": "Pero es posible que su propiedad <strong>todavía no esté segura</strong>. Aún puede haber",
@@ -315,7 +291,6 @@
   },
   "cleanup_hazardous_waste_buried": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Hazardous waste that’s buried",
     "fr": "Déchets dangereux enterrés",
     "es": "desechos peligrosos enterrados",
@@ -328,7 +303,6 @@
   },
   "cleanup_health_hazards_like_ash_and_asbestos": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Health hazards like ash and asbestos",
     "fr": "Dangers pour la santé comme le cendre et l'amiante",
     "es": "peligros para la salud como ceniza y asbesto",
@@ -341,7 +315,6 @@
   },
   "cleanup_or_uppercase": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "OR",
     "fr": "OU",
     "es": "O",
@@ -354,7 +327,6 @@
   },
   "cleanup_deferred_to_phase_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Deferred to Phase 2",
     "fr": "Reporté à la Phase 2",
     "es": "Diferido a la fase 2",
@@ -367,7 +339,6 @@
   },
   "cleanup_deferred_to_phase_2_status": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "This status means the EPA can’t safely clean your property until debris has been removed.",
     "fr": "Ce statut signifie que l'EPA ne peut pas nettoyer votre propriété en toute sécurité avant que les débris ne soient retirés.",
     "es": "Este estado significa que la Agencia de Protección Ambiental no puede limpiar de manera segura su propiedad hasta que se eliminen los escombros.",
@@ -380,7 +351,6 @@
   },
   "cleanup_it_will_be_cleaned_in_phase_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "It will be cleaned in Phase 2.",
     "fr": "Il sera nettoyé dans la Phase 2.",
     "es": "Se limpiará en la fase 2.",
@@ -393,7 +363,6 @@
   },
   "cleanup_see_phase_1_progress": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "See <a href=\"/lafires/track-progress/#phases\">Phase 1 progress</a>.",
     "fr": "Voir <a href=\"/lafires/fr/track-progress/#phases\">le progrès de la Phase 1</a>.",
     "es": "Vea el <a href=\"/lafires/es/track-progress/#phases\">progreso de la fase 1</a>.",
@@ -406,7 +375,6 @@
   },
   "cleanup_us_army_corps_of_engineers_debris_removal": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "In Phase 2, the U.S. Army Corps of Engineers (USACE) removes structural debris.",
     "fr": "Dans la Phase 2, l'ingénieurs du corps des ingénieurs (USACE) retire les débris structuraux.",
     "es": "En la fase 2, el Cuerpo de Ingenieros del Ejército de los Estados Unidos (U.S. Army Corps of Engineers, USACE) elimina los escombros estructurales.",
@@ -419,7 +387,6 @@
   },
   "cleanup_debris_removal_includes": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "This includes:",
     "fr": "Cela inclut:",
     "es": "Esto incluye:",
@@ -432,7 +399,6 @@
   },
   "cleanup_damaged_foundations": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Damaged foundations",
     "fr": "Fondations endommagées",
     "es": "cimientos dañados",
@@ -445,7 +411,6 @@
   },
   "cleanup_destroyed_vehicles": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Destroyed vehicles",
     "fr": "Véhicules détruits",
     "es": "vehículos destruidos",
@@ -458,7 +423,6 @@
   },
   "cleanup_trees_that_are_a_hazard": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Trees that are a hazard",
     "fr": "Arbres qui sont une menace",
     "es": "árboles peligrosos",
@@ -471,7 +435,6 @@
   },
   "cleanup_contaminated_soil": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Contaminated soil",
     "fr": "Sol contaminé",
     "es": "tierra contaminada",
@@ -484,7 +447,6 @@
   },
   "cleanup_asbestos": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Asbestos",
     "fr": "Amiante",
     "es": "asbesto",
@@ -497,7 +459,6 @@
   },
   "cleanup_ash": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Ash",
     "fr": "Cendre",
     "es": "ceniza",
@@ -510,7 +471,6 @@
   },
   "cleanup_what_to_expect_in_phase_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Read <a href=\"https://recovery.lacounty.gov/debris-removal/what-to-expect/\">what to expect in Phase 2</a>.",
     "fr": "Lire <a href=\"https://recovery.lacounty.gov/debris-removal/what-to-expect/\">ce que vous pouvez attendre dans la Phase 2</a>.",
     "es": "Lea <a href=\"https://recovery.lacounty.gov/debris-removal/what-to-expect/\">lo que puede esperar en la fase 2</a>.",
@@ -523,7 +483,6 @@
   },
   "cleanup_see_the_progress_of_this_work_in_usace_s_debris_removal_map": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "See the progress of this work in <a href=\"https://jecop-public.usace.army.mil/portal/apps/experiencebuilder/experience/?id=efbee5617ffa4d17b572d5f312004806\">USACE’s debris removal map</a>.",
     "fr": "Voir le progrès de ce travail dans la <a href=\"https://jecop-public.usace.army.mil/portal/apps/experiencebuilder/experience/?id=efbee5617ffa4d17b572d5f312004806\">carte de retrait de débris de l'USACE</a>.",
     "es": "Vea el progreso de este trabajo en el <a href=\"https://jecop-public.usace.army.mil/portal/apps/experiencebuilder/experience/?id=efbee5617ffa4d17b572d5f312004806\">mapa de remoción de escombros de USACE</a>.",
@@ -536,7 +495,6 @@
   },
   "cleanup_about_removing_trees": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "About removing trees",
     "fr": "À propos de la suppression des arbres",
     "es": "Sobre la remoción de árboles",
@@ -549,7 +507,6 @@
   },
   "cleanup_during_debris_removal_the_usace_will_remove_trees_that_are_hazardous": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "During debris removal, the USACE will remove trees that are hazardous. But you can request that a tree not be removed.",
     "fr": "Lors du retrait de débris, l'USACE retirera les arbres qui sont dangereux. Mais vous pouvez demander que l'arbre ne soit pas retiré.",
     "es": "Durante la remoción de escombros, USACE retirará árboles que son peligrosos. Pero usted puede solicitar que no se retiren.",
@@ -562,7 +519,6 @@
   },
   "cleanup_about_the_waiver_process": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "About the waiver process",
     "fr": "À propos du processus de waiver",
     "es": "Sobre el proceso de exención",
@@ -575,7 +531,6 @@
   },
   "cleanup_tree_markings_explained": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Tree markings explained",
     "fr": "Explication des marques d'arbre",
     "es": "Marcas de los árboles",
@@ -588,7 +543,6 @@
   },
   "cleanup_waiver_form_pdf": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "<a href=\"https://file.lacounty.gov/SDSInter/lac/1178475_WaiverofHazardousTreeRemoval.pdf\">Waiver form</a> (PDF)",
     "fr": "<a href=\"https://file.lacounty.gov/SDSInter/lac/1178475_WaiverofHazardousTreeRemoval.pdf\">Formulaire de waiver</a> (PDF)",
     "es": "<a href=\"https://file.lacounty.gov/SDSInter/lac/1178475_WaiverofHazardousTreeRemoval.pdf\">Formulario de exención</a> (PDF)",
@@ -601,7 +555,6 @@
   },
   "cleanup_how_to_get_debris_removed": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "How to get debris removed",
     "fr": "Comment obtenir le retrait des débris",
     "es": "Cómo pedir que se retiren escombros",
@@ -614,7 +567,6 @@
   },
   "cleanup_debris_removal_opt_in_or_out": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "To get debris removed, you must choose to:",
     "fr": "Pour obtenir le retrait des débris, vous devez choisir de:",
     "es": "Para pedir que se retiren escombros, debe elegir:",
@@ -628,7 +580,6 @@
   },
   "cleanup_opt_in_free_removal": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Opt in for free removal",
     "fr": "Opt in pour le retrait gratuit",
     "es": "Solicitar la remoción gratuita",
@@ -641,7 +592,6 @@
   },
   "cleanup_opt_out_self_removal": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Opt out to arrange and pay for removal yourself",
     "fr": "Opt out pour organiser et payer pour le retrait vous-même",
     "es": "Optar por arreglar y pagar la remoción por su cuenta.",
@@ -654,7 +604,6 @@
   },
   "cleanup_no_out_of_pocket_costs": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "There are no out-of-pocket costs for this service. If you have insurance, your insurer will be billed.",
     "fr": "Il n'y a pas de coûts hors poche pour ce service. Si vous avez une assurance, votre assureur sera facturé.",
     "es": "No hay gastos de bolsillo por este servicio. Si tiene seguro, se le facturará a su aseguradora.",
@@ -667,7 +616,6 @@
   },
   "cleanup_phase_1_completion_required": {
     "status": "ap_review",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "orig_en": "Debris removal can't start until Phase 1 cleanup is completed or deferred.",
     "en": "Debris removal can’t start on your property until Phase 1 is completed or deferred.",
     "fr": "Le retrait de débris ne peut pas commencer sur votre propriété avant que la Phase 1 soit terminée ou reportée.",
@@ -681,7 +629,6 @@
   },
   "cleanup_opt_in_deadline_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Opt in by the deadline",
     "fr": "Opt in avant la date limite",
     "es": "Solicítela antes de la fecha límite.",
@@ -694,7 +641,6 @@
   },
   "cleanup_opt_in_deadline": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "To get free debris removal, you must <strong>opt in by April 15, 2025</strong>.",
     "fr": "Pour obtenir le retrait de débris gratuit, vous devez <strong>opt in avant le 15 avril 2025</strong>.",
     "es": "Para que se retiren los escombros sin cargo, debe <strong>solicitarla antes del 15 de abril de 2025</strong>.",
@@ -708,7 +654,6 @@
   "cleanup_opt_in_form_button_text": {
     "status": "avantpage_delivery",
     "old_key": "cleanup_opt_in_formm_button_text",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Opt in for free removal",
     "fr": "Opt in pour le retrait gratuit",
     "es": "Solicitar la remoción gratuita",
@@ -721,7 +666,6 @@
   },
   "cleanup_opt_in_requirements_intro": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "To complete the opt-in form, you’ll need",
     "fr": "Pour compléter le formulaire d'opt-in, vous aurez besoin de",
     "es": "Para completar el formulario de solicitud, necesitará:",
@@ -734,7 +678,6 @@
   },
   "cleanup_opt_in_owner_info": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Contact info and signatures of all owners of the property",
     "fr": "Informations de contact et signatures de tous les propriétaires de la propriété",
     "es": "información de contacto y firmas de todos los dueños de la propiedad",
@@ -747,7 +690,6 @@
   },
   "cleanup_opt_in_ain": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Assessor’s information number, or AIN",
     "fr": "Numéro d'information de l'assesseur, ou AIN",
     "es": "número de información del evaluador (Assessor's information number, AIN)",
@@ -760,7 +702,6 @@
   },
   "cleanup_opt_in_ain_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Find your AIN",
     "fr": "Trouvez votre AIN",
     "es": "Encuentre su AIN",
@@ -773,7 +714,6 @@
   },
   "cleanup_opt_in_insurance": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Homeowners insurance information (if you’re insured)",
     "fr": "Informations d'assurance propriétaire (si vous êtes assuré)",
     "es": "información sobre el seguro de vivienda (si tiene seguro)",
@@ -786,7 +726,6 @@
   },
   "cleanup_opt_in_vehicle_info": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Vehicle information for any destroyed vehicles on the property",
     "fr": "Informations sur les véhicules pour tous les véhicules détruits sur la propriété",
     "es": "información del vehículo para cualquier vehículo destruido en la propiedad",
@@ -799,7 +738,6 @@
   },
   "cleanup_opt_out_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Opt out at your own expense",
     "fr": "Opt out à votre propre charge",
     "es": "Decida no solicitar la remoción bajo su propia responsabilidad",
@@ -812,7 +750,6 @@
   },
   "cleanup_opt_out_explanation": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "If you opt out of free debris removal, you’ll arrange for and pay for this service yourself.",
     "fr": "Si vous décidez de ne pas opt in pour le retrait de débris gratuit, vous devrez organiser et payer pour ce service vous-même.",
     "es": "Si opta por que no se retiren los escombros gratis, usted organizará y pagará este servicio por su cuenta.",
@@ -825,7 +762,6 @@
   },
   "cleanup_opt_out_requirements_intro": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "This process is complicated and expensive. You must:",
     "fr": "Ce processus est compliqué et coûteux. Vous devez:",
     "es": "Este proceso es complicado y costoso. Usted debe:",
@@ -839,7 +775,6 @@
   },
   "cleanup_opt_out_contractor": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Hire a licensed, specialized contractor",
     "fr": "Engager un entrepreneur agréé et spécialisé",
     "es": "contratar a un profesional autorizado y especializado",
@@ -852,7 +787,6 @@
   },
   "cleanup_opt_out_permit": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Get approval and a permit from LA County",
     "fr": "Obtenir l'approbation et une autorisation de la part du comté de Los Angeles",
     "es": "obtener aprobación y una autorización por parte del condado de Los Ángeles",
@@ -865,7 +799,6 @@
   },
   "cleanup_opt_out_asbestos": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Hire a certified consultant to check your property for asbestos",
     "fr": "Engager un consultant certifié pour vérifier votre propriété pour l'amiante",
     "es": "contratar a un consultor certificado para que revise su propiedad en busca de asbesto",
@@ -878,7 +811,6 @@
   },
   "cleanup_opt_out_compliance": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Make sure your contractor follows all government rules for safe debris removal",
     "fr": "Assurez-vous que votre entrepreneur respecte toutes les règles gouvernementales pour le retrait de débris sûr",
     "es": "asegurarse de que su contratista siga todas las reglas gubernamentales para retirar los escombros de manera segura",
@@ -891,7 +823,6 @@
   },
   "cleanup_how_to_opt_out_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "How to opt out",
     "fr": "Comment opt out",
     "es": "Cómo rechazar la remoción ",
@@ -904,7 +835,6 @@
   },
   "cleanup_opt_out_submit_form": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "If you choose to opt out, submit an <a href=\"https://recovery.lacounty.gov/debris-removal/roe/#1738023329423-9c1c25a7-71e8\">opt-out form</a> to LA County right away.",
     "fr": "Si vous décidez de ne pas opt in, soumettez un <a href=\"https://recovery.lacounty.gov/debris-removal/roe/#1738023329423-9c1c25a7-71e8\">formulaire d'opt-out</a> au comté de Los Angeles dès que possible.",
     "es": "Si decide rechazar la remoción, envíe un <a href=\"https://recovery.lacounty.gov/debris-removal/roe/#1738023329423-9c1c25a7-71e8\">formulario de exclusión voluntaria</a> al condado de Los Ángeles de inmediato.",
@@ -917,7 +847,6 @@
   },
   "cleanup_opt_out_importance": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "It’s important to submit this form so that the county can start free debris removal for your neighbors.",
     "fr": "Il est important de soumettre ce formulaire afin que le comté puisse commencer le retrait de débris gratuit pour vos voisins.",
     "es": "Es importante presentar este formulario para que el condado pueda iniciar la remoción gratis de escombros para sus vecinos.",
@@ -930,7 +859,6 @@
   },
   "cleanup_opt_out_requirements_needed": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "You will need:",
     "fr": "Vous aurez besoin de:",
     "es": "Usted necesitará:",
@@ -944,7 +872,6 @@
   },
   "cleanup_opt_out_contractor_info": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Name and license number of your contractor",
     "fr": "Nom et numéro de licence de votre entrepreneur",
     "es": "nombre y número de licencia de su contratista",
@@ -957,7 +884,6 @@
   },
   "cleanup_opt_out_debris_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Description of the debris you need to remove",
     "fr": "Description des débris que vous devez retirer",
     "es": "descripción de los escombros que debe retirar",
@@ -970,7 +896,6 @@
   },
   "cleanup_opt_out_ain": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Assessor’s information number, or AIN",
     "fr": "Numéro d'information de l'assesseur, ou AIN",
     "es": "número de información del evaluador o AIN",
@@ -983,7 +908,6 @@
   },
   "cleanup_opt_out_ain_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Find your AIN",
     "fr": "Trouvez votre AIN",
     "es": "Encuentre su AIN",
@@ -996,7 +920,6 @@
   },
   "cleanup_help_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "If you need help",
     "fr": "Si vous avez besoin d'aide",
     "es": "Si necesita ayuda",
@@ -1009,7 +932,6 @@
   },
   "cleanup_phase_1_questions_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Questions about Phase 1 cleanup",
     "fr": "Questions sur le nettoyage de la Phase 1",
     "es": "Preguntas sobre la fase 1",
@@ -1022,7 +944,6 @@
   },
   "cleanup_epa_contact": {
     "status": "ap_review",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Call the EPA at <a href=\"tel:833-798-7372\">833-798-7372</a>  (TTY: 711)",
     "fr": "Appeler l'EPA au <a href=\"tel:833-798-7372\">833-798-7372</a> (TTY: 711)",
     "es": "Llame a la Agencia de Protección Ambiental al <a href=\"tel:833-798-7372\">833-798-7372</a> (TTY: 711)",
@@ -1035,7 +956,6 @@
   },
   "cleanup_opt_in_help_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Help filling out the opt-in form",
     "fr": "Aide pour remplir le formulaire d'opt-in",
     "es": "Ayuda para llenar el formulario de inscripción",
@@ -1048,7 +968,6 @@
   },
   "cleanup_county_hotline": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Call the LA County Public Works Debris Removal Hotline at <a href=\"tel:844-347-3332\">844-347-3332</a> (TTY: 711)",
     "fr": "Appeler le hotline de retrait de débris du comté de Los Angeles au <a href=\"tel:844-347-3332\">844-347-3332</a> (TTY: 711)",
     "es": "Llame a la Línea directa de obras públicas para la eliminación de escombros del condado de Los Ángeles al <a href=\"tel:844-347-3332\">844-347-3332</a> (TTY: 711)",
@@ -1061,7 +980,6 @@
   },
   "cleanup_email_contact": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Email <a href=\"mailto:PalisadesFire@dpw.lacounty.gov\">PalisadesFire@dpw.lacounty.gov</a> or <a href=\"mailto:EatonFire@dpw.lacounty.gov\">EatonFire@dpw.lacounty.gov</a>",
     "fr": "Envoyer un email à <a href=\"mailto:PalisadesFire@dpw.lacounty.gov\">PalisadesFire@dpw.lacounty.gov</a> ou <a href=\"mailto:EatonFire@dpw.lacounty.gov\">EatonFire@dpw.lacounty.gov</a>",
     "es": "Correo electrónico <a href=\"mailto:PalisadesFire@dpw.lacounty.gov\">PalisadesFire@dpw.lacounty.gov</a> o <a href=\"mailto:EatonFire@dpw.lacounty.gov\">EatonFire@dpw.lacounty.gov</a>",
@@ -1074,7 +992,6 @@
   },
   "cleanup_in_person_help": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Get help in person at a <a href=\"/lafires/get-help-in-person/\">Disaster Recovery Center</a>",
     "fr": "Obtenir de l'aide en personne à un <a href=\"/lafires/get-help-in-person/\">Centre de récupération des catastrophes</a>",
     "es": "Obtenga ayuda en persona en un <a href=\"/lafires/get-help-in-person/\">centro de recuperación por catástrofes</a>",
@@ -1088,7 +1005,6 @@
   "cleanup_more_info_heading": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "More about cleanup and debris removal",
     "fr": "Plus d'informations sur le nettoyage et le retrait des débris",
     "es": "Más información sobre la limpieza y remoción de escombros",
@@ -1102,7 +1018,6 @@
   "cleanup_la_county_recovers": {
     "old_key": "cleanup_la_county_recovers_heading",
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "LA County Recovers",
     "fr": "LA County Recovers",
     "es": "LA County Recovers",
@@ -1116,7 +1031,6 @@
   "cleanup_where_debris_goes": {
     "old_key": "cleanup_debris_destination_heading",
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Where debris goes",
     "fr": "Où les débris vont",
     "es": "Dónde terminan los escombros",
@@ -1130,7 +1044,6 @@
   "cleanup_debris_disposal_explanation": {
     "old_key": "cleanup_debris_disposal",
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Workers will dispose of debris in a way that protects public health and the environment.",
     "fr": "Les travailleurs disposeront des débris de manière à protéger la santé publique et l'environnement.",
     "es": "Los trabajadores desecharán los escombros de una manera que protege la salud pública y el medio ambiente.",
@@ -1143,7 +1056,6 @@
   },
   "cleanup_calepa_info": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Find out more at CalEPA’s <a href=\"https://calepa.ca.gov/disaster/debris/wildfire-debris-in-landfills-frequently-asked-questions/\">Wildfire Debris in Landfills</a>.",
     "fr": "En savoir plus sur <a href=\"https://calepa.ca.gov/disaster/debris/wildfire-debris-in-landfills-frequently-asked-questions/\">Wildfire Debris in Landfills</a>.",
     "es": "Obtenga más información sobre <a href=\"https://calepa.ca.gov/disaster/debris/wildfire-debris-in-landfills-frequently-asked-questions/\">escombros de incendios forestales en vertederos</a> de la Agencia de Protección Ambiental de California (California Environmental Protection Agency, CalEPA).",
@@ -1156,7 +1068,6 @@
   },
   "cleanup_phase_1_complete": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/cleanup-and-debris-removal-shared.html",
     "en": "Phase 1 Complete",
     "es": "Fase 1 completada",
     "ko": "1단계 완료",

--- a/src/_data/i18n/i18n-feedback.json
+++ b/src/_data/i18n/i18n-feedback.json
@@ -1,7 +1,6 @@
 {
   "feedback_question": {
     "status": "machine translated",
-    "src_file": "src/_includes/feedback.html",
     "en": "Did you find what you were looking for?",
     "es": "¿Encontraste lo que buscabas?",
     "fr": "Avez-vous trouvé ce que vous cherchiez?",
@@ -14,7 +13,6 @@
   },
   "feedback_yes": {
     "status": "machine translated",
-    "src_file": "src/_includes/feedback.html",
     "en": "Yes",
     "es": "Sí",
     "fr": "Oui",
@@ -27,7 +25,6 @@
   },
   "feedback_no": {
     "status": "machine translated",
-    "src_file": "src/_includes/feedback.html",
     "en": "No",
     "es": "No",
     "fr": "Non",
@@ -40,7 +37,6 @@
   },
   "feedback_comment_prompt": {
     "status": "machine translated",
-    "src_file": "src/_includes/feedback.html",
     "en": "What was the problem?",
     "es": "¿Cuál fue el problema?",
     "fr": "Quel était le problème?",
@@ -53,7 +49,6 @@
   },
   "feedback_positive_comment_prompt": {
     "status": "machine translated",
-    "src_file": "src/_includes/feedback.html",
     "en": "Great! What were you looking for today?",
     "es": "¡Genial! ¿Qué estás buscando hoy?",
     "fr": "Génial ! Qu'est-ce que vous cherchez aujourd'hui ?",
@@ -66,7 +61,6 @@
   },
   "feedback_thanks_feedback": {
     "status": "machine translated",
-    "src_file": "src/_includes/feedback.html",
     "en": "Thank you for your feedback!",
     "es": "¡Gracias por tu feedback!",
     "fr": "Merci pour votre feedback!",
@@ -79,7 +73,6 @@
   },
   "feedback_thanks_comments": {
     "status": "machine translated",
-    "src_file": "src/_includes/feedback.html",
     "en": "Thank you for your comments!",
     "es": "¡Gracias por tus comentarios!",
     "fr": "Merci pour vos commentaires!",
@@ -92,7 +85,6 @@
   },
   "feedback_submit": {
     "status": "machine translated",
-    "src_file": "src/_includes/feedback.html",
     "en": "Submit",
     "es": "Enviar",
     "fr": "Envoyer",
@@ -105,7 +97,6 @@
   },
   "feedback_anything_to_add": {
     "status": "machine translated",
-    "src_file": "src/_includes/feedback.html",
     "en": "If you have anything to add,",
     "es": "Si tienes algo que agregar,",
     "fr": "Si vous avez quelque chose à ajouter,",
@@ -118,7 +109,6 @@
   },
   "feedback_any_other_feedback": {
     "status": "machine translated",
-    "src_file": "src/_includes/feedback.html",
     "en": "If you have any other feedback about this website,",
     "es": "Si tienes algún otro comentario sobre este sitio web,",
     "fr": "Si vous avez un autre commentaire sur ce site web,",

--- a/src/_data/i18n/i18n-help-business.json
+++ b/src/_data/i18n/i18n-help-business.json
@@ -1,7 +1,6 @@
 {
   "help_business_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Help your business",
     "fr": "Aidez votre entreprise",
     "es": "Ayuda para su negocio",
@@ -14,7 +13,6 @@
   },
   "help_business_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Find support and assistance for local business recovery.",
     "fr": "Trouvez des ressources et des aides pour la récupération de votre entreprise.",
     "es": "Encontrar apoyo y asistencia para la recuperación de negocios locales.",
@@ -27,7 +25,6 @@
   },
   "help_business_lead_text": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Find support and assistance for local business recovery.",
     "fr": "Trouvez des ressources et des aides pour la récupération de votre entreprise.",
     "es": "Encontrar apoyo y asistencia para la recuperación de negocios locales.",
@@ -41,7 +38,6 @@
   "help_business_recovery_centers_heading": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Find a Business Recovery Center",
     "fr": "Trouvez un centre de récupération des entreprises",
     "es": "Encuentre un centro de recuperación de negocios",
@@ -54,7 +50,6 @@
   },
   "help_business_recovery_centers_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Businesses can get in-person help.",
     "fr": "Les entreprises peuvent obtenir de l'aide en personne.",
     "es": "Los negocios pueden obtener ayuda en persona.",
@@ -67,7 +62,6 @@
   },
   "help_business_west_hollywood_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "West Hollywood Chamber of Commerce",
     "fr": "Chambre de commerce de West Hollywood",
     "es": "West Hollywood Chamber of Commerce",
@@ -80,7 +74,6 @@
   },
   "help_business_west_hollywood_address_line_1": {
     "status": "ap_review",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "8272 Santa Monica Blvd.",
     "fr": "8272 Santa Monica Blvd.",
     "es": "8272 Santa Monica Blvd.",
@@ -93,7 +86,6 @@
   },
   "help_business_west_hollywood_address_line_2": {
     "status": "ap_review",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "West Hollywood, CA 90046",
     "fr": "West Hollywood, CA 90046",
     "es": "West Hollywood, CA 90046",
@@ -106,7 +98,6 @@
   },
   "help_business_directions_link_text": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Directions",
     "fr": "Directions",
     "es": "Indicaciones",
@@ -120,7 +111,6 @@
   "help_business_west_hollywood_hours": {
     "status": "ap_review",
     "comment": "original text was truncated, so I added the missing text",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "<strong>Hours open</strong>: Thursday - Saturday, 9 am to 5:30 pm",
     "fr": "<strong>Heures ouvertes</strong>: Jeudi - Samedi, 9 h à 17 h 30",
     "es": "<strong>Horarios de disponibilidad</strong>: Jueves - Sábado, 9 am a 5:30 pm",
@@ -134,7 +124,6 @@
   },
   "help_business_wbc_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Women’s Business Center",
     "fr": "Centre des affaires des femmes",
     "es": "Centro de Negocios para Mujeres",
@@ -147,7 +136,6 @@
   },
   "help_business_wbc_address_line_1": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "18700 Sherman Way, Suite # 112",
     "fr": "18700 Sherman Way, Suite # 112",
     "es": "18700 Sherman Way, Suite # 112",
@@ -160,7 +148,6 @@
   },
   "help_business_wbc_address_line_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Reseda, CA 91335",
     "fr": "Reseda, CA 91335",
     "es": "Reseda, CA 91335",
@@ -174,7 +161,6 @@
   "help_business_wbc_hours": {
     "status": "ap_review",
     "comment": "original text was truncated, so I added the missing text",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "<strong>Hours open:</strong> Monday - Wednesday, 8:30 am to 5:30",
     "fr": "<strong>Heures ouvertes</strong>: Lundi - Mercredi, 8 h 30 à 17 h 30",
     "es": "<strong>Horarios de disponibilidad:</strong> Lunes - Miércoles, 8:30 am a 5:30 pm",
@@ -188,7 +174,6 @@
   "help_business_wbc_parking": {
     "status": "ap_review",
     "comment": "original text was truncated, so I added the missing text",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "<strong>Parking:</strong> Back of building on Yolanda Ave.",
     "fr": "<strong>Stationnement:</strong> Arrière du bâtiment sur l'avenue Yolanda.",
     "es": "<strong>Estacionamiento:</strong> Parte trasera del edificio en Yolanda Ave.",
@@ -202,7 +187,6 @@
   },
   "help_business_smcc_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Santa Monica Chamber of Commerce",
     "fr": "Chambre de commerce de Santa Monica",
     "es": "Santa Monica Chamber of Commerce",
@@ -215,7 +199,6 @@
   },
   "help_business_smcc_address_line_1": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "2525 Main Street, Suite #103",
     "fr": "2525 Main Street, Suite #103",
     "es": "2525 Main Street, Suite #103",
@@ -228,7 +211,6 @@
   },
   "help_business_smcc_address_line_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Santa Monica, CA 90405",
     "fr": "Santa Monica, CA 90405",
     "es": "Santa Monica, CA 90405",
@@ -242,7 +224,6 @@
   "help_business_smcc_hours": {
     "status": "ap_review",
     "comment": "original text was truncated, so I added the missing text",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "<strong>Hours open:</strong> Monday - Friday, 9 am to 5 pm",
     "fr": "<strong>Heures ouvertes</strong>: Lundi - Vendredi, 9 h à 17 h",
     "es": "<strong>Horarios de disponibilidad:</strong> Lunes - Viernes, 9 am a 5 pm",
@@ -256,7 +237,6 @@
   },
   "help_business_support_businesses_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Support for businesses",
     "fr": "Support pour les entreprises",
     "es": "Apoyo a los negocios",
@@ -269,7 +249,6 @@
   },
   "help_business_sba_support_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Small business support",
     "fr": "Support pour les entreprises",
     "es": "Apoyo a pequeñas empresas",
@@ -282,7 +261,6 @@
   },
   "help_business_sba_support_source": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "by Small Business Administration (SBA)",
     "fr": "par Small Business Administration (SBA)",
     "es": "de la Administración de Pequeñas Empresas (Small Business Administration, SBA)",
@@ -296,7 +274,6 @@
   "help_business_sba_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "The deadline to apply for loans to repair damage to your business was <strong>March 31, 2025</strong>.",
     "fr": "La date limite pour demander des prêts pour réparer les dommages à votre entreprise était le <strong>31 mars 2025</strong>.",
     "es": "El plazo para solicitar préstamos para reparar daños a su empresa fue el <strong>31 de marzo de 2025</strong>.",
@@ -310,7 +287,6 @@
   "help_business_sba_description2": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "You can still apply for a loan to cover economic losses. The deadline to apply for that is <strong>October 25, 2025</strong>.",
     "fr": "Vous pouvez toujours demander un prêt pour couvrir les pertes économiques. La date limite pour demander ce prêt est le <strong>25 octobre 2025</strong>.",
     "es": "Aún puede solicitar un préstamo para cubrir las pérdidas económicas. El plazo para solicitar ese préstamo es el <strong>25 de octubre de 2025</strong>.",
@@ -323,7 +299,6 @@
   },
   "help_business_edd_assistance_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Emergency and disaster assistance for employers",
     "fr": "Aide et assistance pour les employeurs en cas d'urgence et de catastrophe",
     "es": "Asistencia por emergencias y catástrofes para empleadores",
@@ -336,7 +311,6 @@
   },
   "help_business_edd_assistance_source": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "by Employment Development Department (EDD)",
     "fr": "par Employment Development Department (EDD)",
     "es": "del Departamento de Desarrollo de Empleo (Employment Development Department, EDD)",
@@ -349,7 +323,6 @@
   },
   "help_business_edd_assistance_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "EDD offers services to support employers impacted by disasters. This includes disaster relief payments, extensions for payments, and payroll reports.",
     "fr": "EDD offre des services pour soutenir les employeurs touchés par les catastrophes. Cela inclut les paiements de secours en cas de catastrophe, les extensions pour les paiements et les rapports de paie.",
     "es": "El EDD ofrece servicios para apoyar a empleadores afectados por catástrofes. Esto incluye pagos de subsidio por catástrofe, extensiones de pagos e informes de la nómina.",
@@ -362,7 +335,6 @@
   },
   "help_business_calosba_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Resources and steps for business recovery",
     "fr": "Ressources et étapes pour la récupération commerciale",
     "es": "Recursos y pasos para la recuperación de negocios",
@@ -375,7 +347,6 @@
   },
   "help_business_calosba_source": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "by California Office of the Small Business Advocate (CalOSBA)",
     "fr": "par California Office of the Small Business Advocate (CalOSBA)",
     "es": "de la Oficina del Defensor de la Pequeñas Empresas de California (California Office of the Small Business Advocate, CalOSBA)",
@@ -388,7 +359,6 @@
   },
   "help_business_calosba_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "CalOSBA offers resources and support for businesses and workers impacted by the wildfires. This includes financial help, recovery programs, and workforce support.",
     "fr": "CalOSBA offre des ressources et un soutien pour les entreprises et les travailleurs touchés par les incendies de forêts. Cela inclut l'aide financière, les programmes de récupération et le soutien à la main-d'œuvre.",
     "es": "CalOSBA ofrece recursos y apoyo a las empresas y los trabajadores afectados por los incendios forestales. Esto incluye ayuda financiera, programas de recuperación y apoyo financiero.",
@@ -403,7 +373,6 @@
   "help_business_sba_title": {
     "status": "ap_delivery",
     "comment": "machine translated",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Small business support",
     "fr": "Support pour les entreprises",
     "es": "Apoyo a pequeñas empresas",
@@ -417,7 +386,6 @@
   "help_business_sba_source": {
     "status": "ap_delivery",
     "comment": "machine translated",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Small business support",
     "fr": "Support pour les entreprises",
     "es": "Apoyo a pequeñas empresas",
@@ -431,7 +399,6 @@
   "help_business_sba_description3": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "The deadline to apply for an SBA loan has passed (March 31, 2025).",
     "fr": "La date limite pour demander un prêt SBA est passée (31 mars 2025).",
     "es": "La fecha límite para solicitar un préstamo de la SBA ha pasado (31 de marzo de 2025).",
@@ -444,7 +411,6 @@
   },
   "help_business_relief_fund_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "LA Region Small Business Relief Fund",
     "fr": "Fonds de secours pour les petites entreprises de la région de Los Angeles",
     "es": "Fondo de ayuda para pequeñas empresas de la región de LA",
@@ -457,7 +423,6 @@
   },
   "help_business_relief_fund_source": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "by City and County of Los Angeles",
     "fr": "par la ville et le comté de Los Angeles",
     "es": "de la ciudad y el condado de Los Ángeles (LA)",
@@ -470,7 +435,6 @@
   },
   "help_business_relief_fund_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "LA County businesses and nonprofits can get cash grants from $2,000 to $25,000. Submit your application by March 12.",
     "fr": "Les entreprises et les organisations sans but lucratif de Los Angeles County peuvent recevoir des subventions en espèces de 2 000 $ à 25 000 $. Soumettez votre candidature avant le 12 mars.",
     "es": "Las empresas y subsidios del condado de LA pueden obtener subsidios en efectivo de $2,000 a $25,000. Envíe su solicitud antes del 12 de marzo.",
@@ -483,7 +447,6 @@
   },
   "help_business_tax_help_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Tax help and relief",
     "fr": "Aide et assistance fiscale",
     "es": "Ayuda y asistencia fiscal",
@@ -496,7 +459,6 @@
   },
   "help_business_business_taxes_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Business income taxes",
     "fr": "Impôts sur le revenu des entreprises",
     "es": "Impuestos sobre ingresos de negocios",
@@ -509,7 +471,6 @@
   },
   "help_business_business_taxes_source": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "by Franchise Tax Board (FTB)",
     "fr": "par Franchise Tax Board (FTB)",
     "es": "dela Junta de Impuestos de Franquicias (Franchise Tax Board, FTB)",
@@ -522,7 +483,6 @@
   },
   "help_business_business_taxes_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Businesses impacted by the wildfires may postpone filing and paying income taxes. The deadline for them is now October 15, 2025. Only Los Angeles County was granted postponement. If the principal place of business is outside of Los Angeles County, you must file and pay by the normal due dates.",
     "fr": "Les entreprises touchées par les incendies de forêts peuvent reporter le paiement et le dépôt de leurs impôts sur le revenu. La date limite pour eux est maintenant le 15 octobre 2025. Seul le comté de Los Angeles a été autorisé à reporter. Si le siège social principal est situé en dehors du comté de Los Angeles, vous devez déposer et payer par les dates d'échéance normales.",
     "es": "Las empresas afectadas por los incendios forestales pueden posponer la presentación y el pago de impuestos sobre los ingresos. La fecha límite para estos servicios es el 15 de octubre de 2025. Se concedió el aplazamiento solo en el condado de Los Ángeles. Si el lugar principal de la empresa está fuera del condado de Los Ángeles, debe presentar una declaración de impuestos y pagar antes de las fechas de vencimiento normales.",
@@ -535,7 +495,6 @@
   },
   "help_business_sales_tax_relief_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Emergency sales tax or fee relief",
     "fr": "Relief fiscal des ventes en cas d'urgence",
     "es": "Impuesto sobre las ventas de emergencias o asistencia con la tarifa",
@@ -548,7 +507,6 @@
   },
   "help_business_sales_tax_relief_source": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "by CA Department of Tax and Fee Administration (CDTFA)",
     "fr": "par CA Department of Tax and Fee Administration (CDTFA)",
     "es": "del Departamento de Administración de Impuestos y Tarifas de California (California Department of Tax and Fee Administration, CDTFA)",
@@ -561,7 +519,6 @@
   },
   "help_business_sales_tax_relief_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Get emergency relief from penalties and interest. You can also get copies of tax records and up to a 3- month filing extension on your taxes.",
     "fr": "Obtenir un relèvement d'urgence des pénalités et des intérêts. Vous pouvez également obtenir des copies des enregistrements fiscaux et une extension de 3 mois pour le dépôt de vos impôts.",
     "es": "Obtener asistencia de emergencia por multas e intereses. También puede obtener copias de los registros fiscales y hasta una extensión de 3 meses para presentar sus impuestos.",
@@ -574,7 +531,6 @@
   },
   "help_business_payroll_taxes_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Payroll taxes",
     "fr": "Impôts sur la paie",
     "es": "Impuestos de la nómina",
@@ -587,7 +543,6 @@
   },
   "help_business_payroll_taxes_source": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "by Employment Development Department (EDD)",
     "fr": "par Employment Development Department (EDD)",
     "es": "del Departamento de Desarrollo de Empleo (Employment Development Department, EDD)",
@@ -601,7 +556,6 @@
   "help_business_payroll_taxes_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Employers in Los Angeles and Ventura Counties directly affected by the Palisades Fire may request up to a two-month extension. Businesses may have extensions to file their state payroll reports.",
     "fr": "Les employeurs des comtés de Los Angeles et de Ventura directement touchés par le feu de la Palisades peuvent demander une extension de deux mois. Les entreprises peuvent avoir des extensions pour déposer leurs rapports de paie d'État.",
     "es": "Los empleadores de los condados de Los Ángeles y Ventura afectados directamente por el incendio de Palisades pueden solicitar una extensión de hasta dos meses. Es posible que las empresas tengan extensión para presentar sus informes de nómina estatales.",
@@ -614,7 +568,6 @@
   },
   "help_business_file_payroll_reports_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "File their state payroll reports:",
     "fr": "Déposer leurs rapports de paie d'État :",
     "es": "presentar los informes de la nómina del estado:",
@@ -627,7 +580,6 @@
   },
   "help_business_file_payroll_reports_link_text": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Reporting extension",
     "fr": "Extension de déclaration",
     "es": "extensión del informe",
@@ -640,7 +592,6 @@
   },
   "help_business_deposit_payroll_taxes_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Deposit payroll taxes without penalty or interest:",
     "fr": "Déposer les impôts sur la paie sans pénalité ou intérêt :",
     "es": "depositar los impuestos de la nómina sin multas ni intereses:",
@@ -653,7 +604,6 @@
   },
   "help_business_deposit_payroll_taxes_link_text": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Payroll tax extension",
     "fr": "Extension de l'impôt sur la paie",
     "es": "extensión del impuesto de la nómina",
@@ -666,7 +616,6 @@
   },
   "help_business_property_tax_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Property tax",
     "fr": "Impôt sur la propriété",
     "es": "Impuesto sobre la propiedad",
@@ -679,7 +628,6 @@
   },
   "help_business_property_tax_source": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "by the State of California and LA County",
     "fr": "par l'État de Californie et le comté de Los Angeles",
     "es": "del condado de Los Ángeles y el estado de California",
@@ -692,7 +640,6 @@
   },
   "help_business_property_tax_full_description_with_link_markup": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "The state <a href=\"https://www.gov.ca.gov/2025/01/16/governor-newsom-extends-state-property-tax-deadlines-for-la-firestorm-communities-until-april-2026/\">extended the property tax deadline</a> for businesses affected by the LA fires. You can apply for property tax reassessment with the <a href=\"https://assessor.lacounty.gov/tax-relief/disaster-relief\">Los Angeles County Assessor</a>. Learn more about <a href=\"https://www.boe.ca.gov/proptaxes/disaster-relief.htm\">property tax reassessments and base year value transfers</a>.",
     "fr": "L'État a <a href=\"https://www.gov.ca.gov/2025/01/16/governor-newsom-extends-state-property-tax-deadlines-for-la-firestorm-communities-until-april-2026/\">prolongé la date limite pour l'impôt sur la propriété</a> pour les entreprises touchées par les incendies de Los Angeles. Vous pouvez demander une réévaluation de l'impôt sur la propriété avec le <a href=\"https://assessor.lacounty.gov/tax-relief/disaster-relief\">Los Angeles County Assessor</a>. En savoir plus sur <a href=\"https://www.boe.ca.gov/proptaxes/disaster-relief.htm\">la réévaluation de l'impôt sur la propriété et les transferts de valeur de l'année de base</a>.",
     "es": "El estado <a href=\"https://www.gov.ca.gov/2025/01/16/governor-newsom-extends-state-property-tax-deadlines-for-la-firestorm-communities-until-april-2026/\">extendió la fecha límite de impuestos a la propiedad</a> para las empresas afectadas por los incendios de LA. Puede solicitar una reevaluación fiscal de la propiedad con el <a href=\"https://assessor.lacounty.gov/tax-relief/disaster-relief\">tasador del condado de Los Ángeles</a>. Obtenga más información sobre las <a href=\"https://www.boe.ca.gov/proptaxes/disaster-relief.htm\">reevaluaciones de impuestos a la propiedad y las transferencias de valor del año base</a>.",
@@ -707,7 +654,6 @@
   "get_free_debris_removal_title": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Get free debris removal",
     "fr": "Obtenir le nettoyage gratuit des débris",
     "es": "Obtener el limpieza gratuita de escombros",
@@ -721,7 +667,6 @@
   "get_free_debris_removal_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Business owners can now get free debris removal for their commercial properties.",
     "fr": "Les propriétaires d'entreprises peuvent maintenant obtenir un nettoyage gratuit des débris pour leurs propriétés commerciales.",
     "es": "Los propietarios de negocios ahora pueden obtener un limpieza gratuita de escombros para sus propiedades comerciales.",
@@ -735,7 +680,6 @@
   "get_free_debris_removal_description2": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Some commercial properties will not qualify. But LA County encourages you to opt in just in case.",
     "fr": "Certaines propriétés commerciales ne seront pas éligibles. Mais le comté de Los Angeles vous incitera à vous inscrire juste au cas où.",
     "es": "Algunas propiedades comerciales no serán elegibles. Pero el condado de Los Ángeles le animará a inscribirse solo en caso de que.",
@@ -749,7 +693,6 @@
   "get_free_debris_removal_description3": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "You must <strong>opt in by April 15, 2025</strong>.",
     "fr": "Vous devez <strong>vous inscrire avant le 15 avril 2025</strong>.",
     "es": "Debe <strong>optar por el 15 de abril de 2025</strong>.",
@@ -763,7 +706,6 @@
   "get_free_debris_removal_button": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/help-your-business-shared.html",
     "en": "Opt in for free removal",
     "fr": "S'inscrire pour le nettoyage gratuit",
     "es": "Inscribirse para el limpieza gratuita",

--- a/src/_data/i18n/i18n-help-online.json
+++ b/src/_data/i18n/i18n-help-online.json
@@ -1,7 +1,6 @@
 {
   "help_online_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Get help online",
     "fr": "Obtenir de l'aide en ligne",
     "es": "Obtenga ayuda en línea",
@@ -14,7 +13,6 @@
   },
   "help_online_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "You can get help online with food, expenses, shelter, and more.",
     "fr": "Vous pouvez obtenir de l'aide en ligne pour les aliments, les dépenses, le logement et plus encore.",
     "es": "Puede obtener ayuda en línea con alimentos, gastos, alojamiento y mucho más.",
@@ -27,7 +25,6 @@
   },
   "help_online_lead_text": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "You can get help online with food, expenses, shelter, and more.",
     "fr": "Vous pouvez obtenir de l'aide en ligne pour les aliments, les dépenses, le logement et plus encore.",
     "es": "Puede obtener ayuda en línea con alimentos, gastos, alojamiento y mucho más.",
@@ -41,7 +38,6 @@
   "help_online_recovery_services_finder_icon_alt": {
     "status": "ap_review",
     "comment": "was machine translated",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Recovery finder icon",
     "fr": "Icône de recherche de récupération",
     "es": "Icono de búsqueda de recuperación",
@@ -54,7 +50,6 @@
   },
   "help_online_recovery_services_finder_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Recovery services finder",
     "fr": "Recherche de services de récupération",
     "es": "Buscador de servicios de recuperación",
@@ -67,7 +62,6 @@
   },
   "help_online_recovery_services_finder_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Not sure where to start? Answer a few questions. You’ll get a list of services just for you.",
     "fr": "Pas sûr de par où commencer ? Répondez à quelques questions. Vous obtiendrez une liste de services spécifiques à votre situation.",
     "es": "¿No sabe por dónde comenzar? Responda unas cuantas preguntas. Obtendrá una lista de servicios personalizados para usted.",
@@ -80,7 +74,6 @@
   },
   "help_online_disaster_relief_navigator": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "If you want to know all help that’s available for your situation, visit <a href= \"https://wildfires.betterangels.la/\">LA Disaster Relief Navigator</a>.",
     "fr": "Si vous voulez savoir toutes les aides disponibles pour votre situation, visitez <a href= \"https://wildfires.betterangels.la/\">LA Disaster Relief Navigator</a>.",
     "es": "Si desea conocer toda la ayuda disponible para su situación, visite <a href= \"https://wildfires.betterangels.la/\">la guía de ayuda para catástrofes de Los Ángeles (LA)</a>.",
@@ -93,7 +86,6 @@
   },
   "help_online_shelter_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Shelter",
     "fr": "Logement",
     "es": "Refugios",
@@ -107,7 +99,6 @@
   "help_online_shelter_list_title": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Temporary housing",
     "es": "Vivienda temporal",
     "fr": "Logement temporaire",
@@ -121,7 +112,6 @@
   "help_online_shelter_list_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "FEMA’s Individuals and Households Program. It gives 14 days of temporary housing for people who qualify. You could also qualify for several months of rental assistance.",
     "fr": "Programme d'aide aux particuliers et aux ménages de la FEMA. Il offre 14 jours de logement temporaire aux personnes éligibles. Vous pourriez également être éligible à plusieurs mois d'aide au loyer.",
     "es": "Programa para Individuos y Familias de FEMA. Proporciona 14 días de vivienda temporal para las personas que califican. También podría calificar para varios meses de asistencia para el alquiler.",
@@ -134,7 +124,6 @@
   },
   "help_online_food_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Food",
     "fr": "Aliments",
     "es": "Alimentos",
@@ -147,7 +136,6 @@
   },
   "help_online_wic_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "WIC",
     "fr": "WIC",
     "es": "Programa de Nutrición Suplementaria Especial para Mujeres, Bebés y Niños (WIC)",
@@ -160,7 +148,6 @@
   },
   "help_online_wic_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "WIC offers food benefits for mothers with low incomes.",
     "fr": "WIC offre des avantages alimentaires pour les mères avec des revenus faibles.",
     "es": "El Programa de Nutrición Suplementaria Especial para Mujeres, Bebés y Niños (Women, Infants, and Children, WIC) ofrece beneficios de alimentos para madres de bajos ingresos.",
@@ -173,7 +160,6 @@
   },
   "help_online_calfresh_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "CalFresh",
     "fr": "CalFresh",
     "es": "CalFresh",
@@ -187,7 +173,6 @@
   "help_online_calfresh_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Sign up for CalFresh food benefits",
     "fr": "Inscrivez-vous aux prestations alimentaires CalFresh",
     "es": "Inscríbase para recibir beneficios alimentarios de CalFresh",
@@ -200,7 +185,6 @@
   },
   "help_online_food_banks_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Food banks",
     "fr": "Banques alimentaires",
     "es": "Bancos de alimentos",
@@ -213,7 +197,6 @@
   },
   "help_online_food_banks_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Find food banks near you.",
     "fr": "Trouvez des banques alimentaires près de chez vous.",
     "es": "Encuentre bancos de alimentos cerca de usted.",
@@ -226,7 +209,6 @@
   },
   "help_online_pet_help_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Help for your pets",
     "fr": "Aide pour vos animaux",
     "es": "Ayuda para sus mascotas",
@@ -239,7 +221,6 @@
   },
   "help_online_pet_help_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "We have help if you",
     "fr": "Nous avons de l'aide si vous",
     "es": "Podemos ayudarle si usted:",
@@ -252,7 +233,6 @@
   },
   "help_online_lost_a_pet": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "lost a pet",
     "fr": "avez perdu un animal",
     "es": "perdió una mascota",
@@ -265,7 +245,6 @@
   },
   "help_online_had_to_leave_a_pet": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "had to leave a pet behind",
     "fr": "avez dû laisser un animal derrière",
     "es": "tuvo que dejar una mascota atrás",
@@ -278,7 +257,6 @@
   },
   "help_online_need_shelter_for_your_pet": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "need shelter for your pet",
     "fr": "avez besoin d'un refuge pour votre animal",
     "es": "necesita un refugio para su mascota",
@@ -291,7 +269,6 @@
   },
   "help_online_visit_california_animal_response_emergency_support": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Visit <a href=\"https://www.cdfa.ca.gov/AHFSS/Animal_Health/eprs/cares/animal_shelter.html\">California Animal Response Emergency Support</a>.",
     "fr": "Visitez <a href=\"https://www.cdfa.ca.gov/AHFSS/Animal_Health/eprs/cares/animal_shelter.html\">Support d'urgence pour les animaux de Californie</a>.",
     "es": "Visite <a href=\"https://www.cdfa.ca.gov/AHFSS/Animal_Health/eprs/cares/animal_shelter.html\">Equipo de Respuesta ante Emergencias para Animales de California</a>.",
@@ -304,7 +281,6 @@
   },
   "help_online_mental_health_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Mental health",
     "fr": "Santé mentale",
     "es": "Salud mental",
@@ -318,7 +294,6 @@
   "help_online_free_crisis_counseling": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Crisis counseling",
     "fr": "Conseil en cas de crise",
     "es": "Asesoramiento en crisis",
@@ -331,7 +306,6 @@
   },
   "help_online_available_online_or_in_person": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Available online or in person",
     "fr": "Disponible en ligne ou en personne",
     "es": "disponibilidad en línea o en persona",
@@ -344,7 +318,6 @@
   },
   "help_online_mental_health_resources_for_youth": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Mental health resources for youth",
     "fr": "Ressources pour la santé mentale des jeunes",
     "es": "Recursos de salud mental para jóvenes",
@@ -357,7 +330,6 @@
   },
   "help_online_by_california_health_and_human_services_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "by California Health and Human Services Agency (CalHHS)",
     "fr": "par le California Health and Human Services Agency (CalHHS)",
     "es": "de la Agencia de Salud y Servicios Humanos de California (California Health and Human Services Agency, CalHHS)",
@@ -371,7 +343,6 @@
   "help_online_wildfire_relief": {
     "status": "ap_review",
     "comment": "was machine translated",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Wildfire relief",
     "fr": "Relief pour les incendies de forêts",
     "es": "Ayuda para incendios forestales",
@@ -385,7 +356,6 @@
   "help_online_from_didi_hirsch_suicide_prevention_center": {
     "status": "ap_review",
     "comment": "was machine translated",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "from Didi Hirsch Suicide Prevention Center",
     "fr": "de Didi Hirsch Suicide Prevention Center",
     "es": "del Centro de Prevención del Suicidio Didi Hirsch",
@@ -399,7 +369,6 @@
   "help_online_disaster_mental_health_resources": {
     "status": "ap_review",
     "comment": "was machine translated",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Disaster mental health resources",
     "fr": "Ressources pour la santé mentale des catastrophes",
     "es": "Recursos de salud mental para desastres",
@@ -413,7 +382,6 @@
   "help_online_from_los_angeles_county_department_of_mental_health": {
     "status": "ap_review",
     "comment": "was machine translated",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "from Los Angeles County Department of Mental Health",
     "fr": "de Los Angeles County Department of Mental Health",
     "es": "del Departamento de Salud Mental del Condado de Los Ángeles",
@@ -427,7 +395,6 @@
   "help_online_wildfires_and_mental_health": {
     "status": "ap_review",
     "comment": "was machine translated",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Wildfires and mental health",
     "fr": "Incendies de forêts et santé mentale",
     "es": "Incendios forestales y salud mental",
@@ -441,7 +408,6 @@
   "help_online_from_california_department_of_public_health": {
     "status": "ap_review",
     "comment": "was machine translated",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "from California Department of Public Health (CDPH)",
     "fr": "de California Department of Public Health (CDPH)",
     "es": "del Departamento de Salud Pública de California (California Department of Public Health, CDPH)",
@@ -454,7 +420,6 @@
   },
   "help_online_replacing_personal_documents_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Replacing your personal documents",
     "fr": "Remplacer vos documents personnels",
     "es": "Remplazo de sus documentos personales",
@@ -467,7 +432,6 @@
   },
   "help_online_ids_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "IDs",
     "fr": "IDs",
     "es": "Tarjetas de identificación",
@@ -480,7 +444,6 @@
   },
   "help_online_social_security_card": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Social Security card",
     "fr": "Carte de sécurité sociale",
     "es": "tarjeta del Seguro Social",
@@ -493,7 +456,6 @@
   },
   "help_online_us_passport": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "U.S. passport",
     "fr": "Passeport des États-Unis",
     "es": "pasaporte estadounidense",
@@ -506,7 +468,6 @@
   },
   "help_online_military_veteran_id": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Military or veteran ID",
     "fr": "ID militaire ou vétéran",
     "es": "identificación militar o de veterano",
@@ -519,7 +480,6 @@
   },
   "help_online_drivers_license": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Driver’s license or California ID card",
     "fr": "Permis de conduire ou carte d'identité de Californie",
     "es": "licencia de conducir o tarjeta de identificación de California",
@@ -532,7 +492,6 @@
   },
   "help_online_no_fees_to_replace_cards": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "No fees to replace cards lost in the fires. You can also call",
     "fr": "Pas de frais pour remplacer les cartes perdues dans les incendies. Vous pouvez également appeler",
     "es": "No tiene que pagar nada para reemplazar las tarjetas que se perdieron en los incendios. También puede llamar al:",
@@ -545,7 +504,6 @@
   },
   "help_online_dmv_phone": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "<a href=\"tel:8007770133\">1-800-777-0133</a>",
     "fr": "<a href=\"tel:8007770133\">1-800-777-0133</a>",
     "es": "<a href=\"tel:8007770133\">1-800-777-0133</a>",
@@ -559,7 +517,6 @@
   },
   "help_online_dmv_tty_phone": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Or <a href=\"tel:8007352929\">TTY 1-800-735-2929</a> or <a href=\"tel:8003684327\">1-800-368-4327</a> for hearing or speech-impaired.",
     "fr": "Ou <a href=\"tel:8007352929\">TTY 1-800-735-2929</a> ou <a href=\"tel:8003684327\">1-800-368-4327</a> pour les personnes sourdes ou malentendantes.",
     "es": "al <a href=\"tel:8007352929\">TTY 1-800-735-2929</a> o al <a href=\"tel:8003684327\">1-800-368-4327</a> para personas con deficiencias auditivas o del habla.",
@@ -572,7 +529,6 @@
   },
   "help_online_citizenship_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Citizenship",
     "fr": "Citoyenneté",
     "es": "Ciudadanía",
@@ -585,7 +541,6 @@
   },
   "help_online_naturalization_certificate": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Certificate of naturalization or citizenship",
     "fr": "Certificat de nationalisation ou de citoyenneté",
     "es": "certificado de naturalización o ciudadanía",
@@ -598,7 +553,6 @@
   },
   "help_online_green_card": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "U.S. Permanent Resident Card (Green Card)",
     "fr": "Carte de résident permanent des États-Unis (carte verte)",
     "es": "tarjeta de residente permanente de los Estados Unidos (tarjeta verde o 'green card')",
@@ -611,7 +565,6 @@
   },
   "help_online_titles_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Titles",
     "fr": "Titres",
     "es": "Títulos",
@@ -624,7 +577,6 @@
   },
   "help_online_vehicle_titles": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Vehicle titles",
     "fr": "Titres de véhicules",
     "es": "Títulos de vehículos",
@@ -637,7 +589,6 @@
   },
   "help_online_no_fees_to_replace_titles": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "No fees to replace titles lost in the fires. You can also call:",
     "fr": "Pas de frais pour remplacer les titres perdus dans les incendies. Vous pouvez également appeler :",
     "es": "No tiene que pagar nada para reemplazar los títulos que se perdieron en los incendios. También puede llamar al:",
@@ -650,7 +601,6 @@
   },
   "help_online_dmv_phone_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "<link>1-800-777-0133</link>",
     "fr": "<link>1-800-777-0133</link>",
     "es": "<link>1-800-777-0133,</link>",
@@ -663,7 +613,6 @@
   },
   "help_online_dmv_tty_phone_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Or <link1>TTY 1-800-735-2929</link1> or <link2>1-800-368-4327</link2> for hearing or speech-impaired.",
     "fr": "Ou <link1>TTY 1-800-735-2929</link1> ou <link2>1-800-368-4327</link2> pour les personnes sourdes ou malentendantes.",
     "es": "al <link1>TTY 1-800-735-2929</link1> o al <link2>1-800-368-4327</link2> para personas con deficiencias auditivas o del habla.",
@@ -676,7 +625,6 @@
   },
   "help_online_birth_marriage_death_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Birth, marriage, and death certificates",
     "fr": "Certificats de naissance, mariage et décès",
     "es": "Actas de nacimiento, matrimonio y defunción",
@@ -689,7 +637,6 @@
   },
   "help_online_see_how_to_order": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "See how to order replacements.",
     "fr": "Voir comment commander des remplacements.",
     "es": "Vea cómo pedir nuevas copias.",
@@ -702,7 +649,6 @@
   },
   "help_online_get_copies_button": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Get copies of vital records",
     "fr": "Obtenir des copies des enregistrements vitaux",
     "es": "Obtenga copias de sus documentos de registro civil.",
@@ -715,7 +661,6 @@
   },
   "help_online_employment_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Employment",
     "fr": "Emploi",
     "es": "Empleo",
@@ -728,7 +673,6 @@
   },
   "help_online_edd_services_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Services from the California Employment Development Department (EDD)",
     "fr": "Services du California Employment Development Department (EDD)",
     "es": "Servicios del Departamento de Desarrollo de Empleo (Employment Development Department, EDD) de California",
@@ -741,7 +685,6 @@
   },
   "help_online_get_help_with": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Get help with",
     "fr": "Obtenir de l'aide avec",
     "es": "Obtenga ayuda con:",
@@ -754,7 +697,6 @@
   },
   "help_online_state_unemployment": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "State <a href=\"https://edd.ca.gov/en/unemployment/disaster_unemployment_assistance\">unemployment</a> insurance benefits",
     "fr": "Assistance de chômage de l'État <a href=\"https://edd.ca.gov/en/unemployment/disaster_unemployment_assistance\">unemployment</a> insurance benefits",
     "es": "beneficios del seguro por <a href=\"https://edd.ca.gov/en/unemployment/disaster_unemployment_assistance\">desempleo</a> estatal",
@@ -767,7 +709,6 @@
   },
   "help_online_federal_disaster_unemployment": {
     "status": "avantpage_delivered",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Federal <a href=\"https://edd.ca.gov/en/unemployment/Disaster_Unemployment_Assistance/\">disaster unemployment assistance</a> ",
     "fr": "Assistance de chômage fédérale <a href=\"https://edd.ca.gov/en/unemployment/Disaster_Unemployment_Assistance/\">disaster unemployment assistance</a> ",
     "es": "asistencia federal para desempleo por <a href=\"https://edd.ca.gov/en/unemployment/Disaster_Unemployment_Assistance/\">catástrofes</a>",
@@ -781,7 +722,6 @@
   },
   "help_online_state_disability": {
     "status": "avantpage_delivered",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "State <a href=\"https://edd.ca.gov/en/disability/disability_insurance/\">disability</a> insurance and <a href=\"https://edd.ca.gov/en/disability/paid-family-leave/\">paid family leave</a>",
     "fr": "Assurance de <a href=\"https://edd.ca.gov/en/disability/disability_insurance/\">handicap</a> de l'État et <a href=\"https://edd.ca.gov/en/disability/paid-family-leave/\">congé de famille payé</a>",
     "es": "seguro estatal por <a href=\"https://edd.ca.gov/en/disability/disability_insurance/\">discapacidad</a> y <a href=\"https://edd.ca.gov/en/disability/paid-family-leave/\">permiso de ausencia remunerada por motivos familiares</a>",
@@ -795,7 +735,6 @@
   },
   "help_online_job_opportunities": {
     "status": "avantpage_delivered",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "<a href=\"https://edd.ca.gov/en/jobs/\">Job opportunities</a> and <a href=\"https://edd.ca.gov/en/jobs_and_training/Training_Information/\">training</a>",
     "fr": "<a href=\"https://edd.ca.gov/en/jobs/\">Opportunités d'emploi</a> et <a href=\"https://edd.ca.gov/en/jobs_and_training/Training_Information/\">formation</a>",
     "es": "<a href=\"https://edd.ca.gov/en/jobs/\">oportunidades de empleo</a> y <a href=\"https://edd.ca.gov/en/jobs_and_training/Training_Information/\">capacitación</a>",
@@ -808,7 +747,6 @@
   },
   "help_online_housing_repairs_legal_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Housing, repairs, and legal help",
     "fr": "Logement, réparations et aide juridique",
     "es": "Vivienda, reparaciones y ayuda legal",
@@ -821,7 +759,6 @@
   },
   "help_online_la_county_relief_grant_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "LA County Household Relief Grant",
     "fr": "Subvention de la maison de Los Angeles",
     "es": "Subsidio para asistencia familiar del condado de Los Ángeles",
@@ -834,7 +771,6 @@
   },
   "help_online_la_county_relief_grant_deadline": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Must apply by March 12, 2025",
     "fr": "Doit s'inscrire avant le 12 mars 2025",
     "es": "Debe aplicar antes del 12 de marzo de 2025",
@@ -847,7 +783,6 @@
   },
   "help_online_la_county_relief_grant_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "This grant helps people displaced by the fires. Eligible households can get grants of up to $18,000.",
     "fr": "Cette subvention aide les personnes déplacées par les incendies. Les ménages éligibles peuvent recevoir des subventions de 18 000 $.",
     "es": "Este subsidio ayuda a las personas desplazadas por los incendios. Los familias elegibles pueden obtener subsidios de hasta $18,000.",
@@ -860,7 +795,6 @@
   },
   "help_online_fema_assistance_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Individual Assistance (FEMA)",
     "fr": "Assistance individuelle (FEMA)",
     "es": "Asistencia Individual (FEMA)",
@@ -874,7 +808,6 @@
   "help_online_fema_deadline": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "The deadline to apply was March 31, 2025",
     "fr": "La date limite pour postuler était le 31 mars 2025",
     "es": "La fecha límite para solicitar fue el 31 de marzo de 2025",
@@ -888,7 +821,6 @@
   "help_online_fema_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Individual Assistance is a group of federal programs that help disaster survivors. This includes:",
     "fr": "L'assistance individuelle est un ensemble de programmes fédéraux qui aident les survivants de catastrophes. Cela comprend :",
     "es": "La Asistencia Individual es un grupo de programas federales que ayudan a los sobrevivientes de desastres. Esto incluye:",
@@ -901,7 +833,6 @@
   },
   "help_online_fema_assistance_list_housing": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Housing",
     "fr": "Logement",
     "es": "vivienda",
@@ -914,7 +845,6 @@
   },
   "help_online_fema_assistance_list_repairs": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Funds for repairs",
     "fr": "Fonds pour les réparations",
     "es": "fondos para reparaciones",
@@ -927,7 +857,6 @@
   },
   "help_online_fema_assistance_list_disabilities": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Help for people with disabilities",
     "fr": "Aide pour les personnes handicapées",
     "es": "ayuda para las personas con discapacidad",
@@ -940,7 +869,6 @@
   },
   "help_online_fema_assistance_list_legal": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Legal services",
     "fr": "Services juridiques",
     "es": "servicios legales",
@@ -953,7 +881,6 @@
   },
   "help_online_fema_news_updates": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Learn more on <a href=\"https://www.fema.gov/disaster/4856\">FEMA’s LA Fires page</a> or view <a href=\"https://www.fema.gov/disaster/4856/news-media\">FEMA’s news updates</a>.",
     "fr": "En savoir plus sur la page <a href=\"https://www.fema.gov/disaster/4856\">FEMA's LA Fires page</a> ou consultez <a href=\"https://www.fema.gov/disaster/4856/news-media\">FEMA's news updates</a>.",
     "es": "Obtenga más información en la <a href=\"https://www.fema.gov/disaster/4856\">página de FEMA para los incendios de LA</a> o consulte las <a href=\"https://www.fema.gov/disaster/4856/news-media\">actualizaciones de FEMA</a>.",
@@ -966,7 +893,6 @@
   },
   "help_online_mortgage_relief_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Mortgage relief",
     "fr": "Relief hypothécaire",
     "es": "Asistencia hipotecaria",
@@ -979,7 +905,6 @@
   },
   "help_online_mortgage_relief_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Get mortgage relief for structures damaged or destroyed by the LA fires. The state worked with major lenders to offer this relief. Over 400 lenders committed to:",
     "fr": "Obtenir un relief hypothécaire pour les structures endommagées ou détruites par les incendies de Los Angeles. L'État a travaillé avec des prêteurs majeurs pour offrir ce relèvement. Plus de 400 prêteurs ont engagé :",
     "es": "Obtener asistencia hipotecaria por estructuras dañadas o destruidas por los incendios de LA. El estado trabajó con grandes prestamistas para ofrecer este beneficio. Más de 400 prestamistas se comprometieron a:",
@@ -992,7 +917,6 @@
   },
   "help_online_mortgage_relief_list_1": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Reduce or pause mortgage payments for 90 days",
     "fr": "Réduire ou suspendre les paiements hypothécaires pendant 90 jours",
     "es": "Reducir o pausar los pagos hipotecarios durante 90 días.",
@@ -1005,7 +929,6 @@
   },
   "help_online_mortgage_relief_list_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Waive late fees for 90 days",
     "fr": "Exonérer les frais de retard pour 90 jours",
     "es": "Hacer una exención de las tarifas por pagos atrasados por 90 días.",
@@ -1018,7 +941,6 @@
   },
   "help_online_mortgage_relief_list_3": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Protect owners from new foreclosures or evictions for 60 days",
     "fr": "Protéger les propriétaires contre les nouvelles saisies ou les expulsions pour 60 jours",
     "es": "Proteger a los dueños de nuevas ejecuciones hipotecarias o desalojo durante 60 días.",
@@ -1031,7 +953,6 @@
   },
   "help_online_mortgage_relief_list_4": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Not report late payments to credit agencies",
     "fr": "Ne pas signaler les paiements en retard aux agences de crédit",
     "es": "No informar a las agencias de crédito sobre pagos atrasados.",
@@ -1044,7 +965,6 @@
   },
   "help_online_mortgage_relief_note": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "You must contact your mortgage lender to get relief. It does not happen automatically.",
     "fr": "Vous devez contacter votre prêteur hypothécaire pour obtenir un relèvement. Cela ne se produit pas automatiquement.",
     "es": "Debe comunicarse con el banco de su crédito hipotecario para obtener asistencia. No la recibirá automáticamente.",
@@ -1057,7 +977,6 @@
   },
   "help_online_mortgage_relief_resources": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Visit <a href=\"https://dfpi.ca.gov/lafires/relief/\">Mortgage relief resources</a> for a list of participating lenders and more.",
     "fr": "Visitez <a href=\"https://dfpi.ca.gov/lafires/relief/\">Mortgage relief resources</a> pour une liste des prêteurs participant et plus encore.",
     "es": "Visite <a href=\"https://dfpi.ca.gov/lafires/relief/\">los recursos de asistencia hipotecaria</a> para obtener una lista de prestamistas participantes y mucho más.",
@@ -1070,7 +989,6 @@
   },
   "help_online_renter_protection_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Renter protection",
     "fr": "Protection locative",
     "es": "Protección del inquilino",
@@ -1083,7 +1001,6 @@
   },
   "help_online_renter_protection_eviction_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Protection from eviction",
     "fr": "Protection contre les expulsions",
     "es": "Protección contra el desalojo",
@@ -1096,7 +1013,6 @@
   },
   "help_online_renter_protection_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "The LA County Board of Supervisors has <a href=\"https://caanet.org/l-a-county-adopts-eviction-moratorium-rental-assistance-funding-remains-uncertain/#:~:text=The%20Los%20Angeles%20County%20Board,funding%20for%20unpaid%20landlords%20continue.\">prohibited evictions for tenants who qualify</a>. This protection lasts through July 31, 2025. See <a href=\"https://dcba.lacounty.gov/wp-content/uploads/2025/02/January-2025-Wildfire-and-Critical-Windstorm-Resolution-FAQ-ENG-2.28.25.pdf\">FAQs about this resolution (PDF)</a>.",
     "fr": "Le conseil des superviseurs de Los Angeles a <a href=\"https://caanet.org/l-a-county-adopts-eviction-moratorium-rental-assistance-funding-remains-uncertain/#:~:text=The%20Los%20Angeles%20County%20Board,funding%20for%20unpaid%20landlords%20continue.\">interdit les expulsions pour les locataires qui remplissent les conditions</a>. Cette protection dure jusqu'au 31 juillet 2025. Voir <a href=\"https://dcba.lacounty.gov/wp-content/uploads/2025/02/January-2025-Wildfire-and-Critical-Windstorm-Resolution-FAQ-ENG-2.28.25.pdf\">FAQs sur cette résolution (PDF)</a>.",
     "es": "La Junta de Supervisores (Board of Supervisors) del condado de LA <a href=\"https://caanet.org/l-a-county-adopts-eviction-moratorium-rental-assistance-funding-remains-uncertain/#:~:text=The%20Los%20Angeles%20County%20Board,funding%20for%20unpaid%20landlords%20continue.\">prohibió el desalojo de inquilinos que califican</a>. Esta protección dura hasta el 31 de julio de 2025. Consulte las <a href=\"https://dcba.lacounty.gov/wp-content/uploads/2025/02/January-2025-Wildfire-and-Critical-Windstorm-Resolution-FAQ-ENG-2.28.25.pdf\">preguntas frecuentes sobre esta resolución (PDF)</a>.",
@@ -1110,7 +1026,6 @@
   "help_online_renter_protection_city_description": {
     "status": "ap_review",
     "comment": "missing links added",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "The City of Los Angeles <a href=\"https://housing.lacity.gov/renter-protections-2\">protects eligible tenants from eviction</a>. The protection lasts through July 31, 2025. You are eligible if you lost wages because:",
     "fr": "La ville de Los Angeles <a href=\"https://housing.lacity.gov/renter-protections-2\">protège les locataires éligibles contre les expulsions</a>. Cette protection dure jusqu'au 31 juillet 2025. Vous êtes éligible si vous avez perdu des revenus en raison de:",
     "es": "La ciudad de Los Ángeles <a href=\"https://housing.lacity.gov/renter-protections-2\">protege los inquilinos elegibles del desalojo</a>. Esta protección dura hasta el 31 de julio de 2025. Usted es elegible si perdió ingresos porque:",
@@ -1124,7 +1039,6 @@
   },
   "help_online_renter_protection_eligibility_1": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "The wildfires destroyed your workplace or rendered it unusable, or",
     "fr": "Les incendies ont détruit votre lieu de travail ou l'ont rendu inutilisable, ou",
     "es": "los incendios destruyeron su lugar de trabajo o lo dejaron inservible; o",
@@ -1137,7 +1051,6 @@
   },
   "help_online_renter_protection_eligibility_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Your employer laid you off or reduced your working hours, or",
     "fr": "Votre employeur vous a licencié ou réduit votre temps de travail, ou",
     "es": "su empleador lo despidió o redujo su horario de trabajo, o",
@@ -1150,7 +1063,6 @@
   },
   "help_online_renter_protection_eligibility_3": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "You had clients located in the wildfires, so you lost income.",
     "fr": "Vous aviez des clients situés dans les incendies, donc vous avez perdu des revenus.",
     "es": "usted tenía clientes ubicados en los incendios, por lo que perdió sus ingresos.",
@@ -1163,7 +1075,6 @@
   },
   "help_online_renter_protection_note_1": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Tenants are also protected from evictions for renovations through this date.",
     "fr": "Les locataires sont également protégés contre les expulsions pour des rénovations jusqu'à cette date.",
     "es": "Los inquilinos también están protegidos contra desalojos por renovaciones hasta esta fecha.",
@@ -1176,7 +1087,6 @@
   },
   "help_online_renter_protection_note_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "If you need eviction protection in the City or County of Los Angeles, you must notify your landlord. Send a <a href=\"https://dcba.lacounty.gov/wp-content/uploads/2025/02/Notice-to-Landlord-of-Inability-to-Pay-Rent-January-2025-Windstorm-and-Critical-Wildfire-Events-2.28.25.pdf\">Notice to Landlord of Inability to Pay Rent (PDF)</a>.",
     "fr": "Si vous avez besoin de protection contre les expulsions dans la ville ou le comté de Los Angeles, vous devez informer votre propriétaire. Envoyer un <a href=\"https://dcba.lacounty.gov/wp-content/uploads/2025/02/Notice-to-Landlord-of-Inability-to-Pay-Rent-January-2025-Windstorm-and-Critical-Wildfire-Events-2.28.25.pdf\">Notice to Landlord of Inability to Pay Rent (PDF)</a>.",
     "es": "Si necesita protección de desalojo en la ciudad o el condado de Los Ángeles, debe notificar al propietario. Envíe un <a href=\"https://dcba.lacounty.gov/wp-content/uploads/2025/02/Notice-to-Landlord-of-Inability-to-Pay-Rent-January-2025-Windstorm-and-Critical-Wildfire-Events-2.28.25.pdf\">aviso al propietario sobre la incapacidad de pagar el alquiler (PDF)</a>.",
@@ -1189,7 +1099,6 @@
   },
   "help_online_renter_protection_mediation_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Free mediation",
     "fr": "Médiation gratuite",
     "es": "Mediación gratuita",
@@ -1202,7 +1111,6 @@
   },
   "help_online_renter_protection_mediation": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "The Department of Consumer and Business Affairs (DCBA) offers free mediation services. They help tenants and landlords work out a payment plan. Call <a href=\"tel:8005938222\">(800) 593-8222</a> to learn more.",
     "fr": "Le Département des consommateurs et des affaires commerciales (DCBA) offre des services de médiation gratuits. Ils aident les locataires et les propriétaires à mettre en place un plan de paiement. Appeler <a href=\"tel:8005938222\">(800) 593-8222</a> pour en savoir plus.",
     "es": "El Departamento de Asuntos de Empresas y Consumidores (Department of Consumer and Business Affairs, DCBA) ofrece servicios de mediación gratuitos. Ayudan a los inquilinos y propietarios a elaborar un plan de pago. Llame al <a href=\"tel:8005938222\">(800) 593-8222</a> para obtener más información.",
@@ -1216,7 +1124,6 @@
   },
   "help_online_help_for_immigrants_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Help for immigrants",
     "fr": "Aide pour les immigrants",
     "es": "Ayuda para inmigrantes",
@@ -1229,7 +1136,6 @@
   },
   "help_online_immigrants_guide_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Disaster Assistance Guide for Immigrants",
     "fr": "Guide d'assistance aux victimes des catastrophes pour les immigrants",
     "es": "Guía de asistencia ante catástrofes para inmigrantes",
@@ -1242,7 +1148,6 @@
   },
   "help_online_immigrants_guide_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "You can <a href=\"https://cdss.ca.gov/disaster-help-center\">get the guide</a> in 5 languages",
     "fr": "Vous pouvez <a href=\"https://cdss.ca.gov/disaster-help-center\">obtenir le guide</a> dans 5 langues",
     "es": "Puede <a href=\"https://cdss.ca.gov/disaster-help-center\">obtener la guía</a> en 5 idiomas:",
@@ -1256,7 +1161,6 @@
   },
   "help_online_immigrants_guide_languages_1": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "English",
     "fr": "Anglais",
     "es": "inglés",
@@ -1269,7 +1173,6 @@
   },
   "help_online_immigrants_guide_languages_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Spanish",
     "fr": "Espagnol",
     "es": "español",
@@ -1282,7 +1185,6 @@
   },
   "help_online_immigrants_guide_languages_3": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Simplified Chinese",
     "fr": "Chinois simplifié",
     "es": "chino simplificado",
@@ -1295,7 +1197,6 @@
   },
   "help_online_immigrants_guide_languages_4": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Traditional Chinese",
     "fr": "Chinois traditionnel",
     "es": "chino tradicional",
@@ -1308,7 +1209,6 @@
   },
   "help_online_immigrants_guide_languages_5": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Armenian",
     "fr": "Arménien",
     "es": "armenio",
@@ -1321,7 +1221,6 @@
   },
   "help_online_student_loans_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Help with student loans",
     "fr": "Aide pour les prêts étudiants",
     "es": "Ayuda con préstamos estudiantiles",
@@ -1334,7 +1233,6 @@
   },
   "help_online_student_loans_source": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "from the Department of Financial Protection and Innovation (DFPI)",
     "es": "del Departamento de Protección Financiera e Innovación (Department of Financial Protection and Innovation, DFPI)",
     "ko": "금융보호 및 혁신국(DFPI) 제공",
@@ -1346,7 +1244,6 @@
   },
   "help_online_student_loans_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "If the fires affected you and you have student loans, you may be eligible for relief.",
     "fr": "Si les incendies ont affecté vous et que vous avez des prêts étudiants, vous pouvez être éligible à un relèvement.",
     "es": "Si usted fue afectado por los incendios y tiene préstamos estudiantiles, podría ser elegible para recibir ayuda.",
@@ -1359,7 +1256,6 @@
   },
   "help_online_student_loans_faq": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "See <a href=\"https://dfpi.ca.gov/lafires/federal-and-private-student-loan-relief-faq/\">Student Loan Relief FAQ</a>.",
     "fr": "Voir <a href=\"https://dfpi.ca.gov/lafires/federal-and-private-student-loan-relief-faq/\">Student Loan Relief FAQ</a>.",
     "es": "Consulte las <a href=\"https://dfpi.ca.gov/lafires/federal-and-private-student-loan-relief-faq/\">preguntas frecuentes sobre asistencia para préstamos estudiantiles</a>.",
@@ -1373,7 +1269,6 @@
   },
   "help_online_avoiding_price_gouging_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Avoiding price gouging",
     "fr": "Éviter la hausse des prix",
     "es": "Cómo evitar el alza de precios",
@@ -1386,7 +1281,6 @@
   },
   "help_online_price_gouging_protection_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Consumer protections against price gouging",
     "fr": "Protection contre la hausse des prix",
     "es": "Protección del consumidor contra el alza de precios",
@@ -1399,7 +1293,6 @@
   },
   "help_online_price_gouging_protection_source": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "from the Office of the Attorney General",
     "fr": "de l'Office de l'avocat général",
     "es": "de la Oficina del Fiscal General",
@@ -1412,7 +1305,6 @@
   },
   "help_online_price_gouging_info_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "About price gouging",
     "fr": "À propos de la hausse des prix",
     "es": "Acerca del alza de precios",
@@ -1425,7 +1317,6 @@
   },
   "help_online_price_gouging_info_source": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "from Los Angeles County",
     "fr": "du comté de Los Angeles",
     "es": "del condado de Los Ángeles",
@@ -1438,7 +1329,6 @@
   },
   "help_online_price_gouging_complaint_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Consumer protection complaint form",
     "fr": "Formulaire de plainte contre la hausse des prix",
     "es": "Formulario de queja de protección al consumidor",
@@ -1451,7 +1341,6 @@
   },
   "help_online_price_gouging_complaint_source": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "from Los Angeles County",
     "fr": "du comté de Los Angeles",
     "es": "del condado de Los Ángeles",
@@ -1464,7 +1353,6 @@
   },
   "help_online_price_gouging_la_complaint_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Price gouging complaint form",
     "fr": "Formulaire de plainte contre la hausse des prix",
     "es": "Formulario de queja de alza de precios",
@@ -1477,7 +1365,6 @@
   },
   "help_online_price_gouging_la_complaint_source": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "from the City of Los Angeles",
     "fr": "de la ville de Los Angeles",
     "es": "de la ciudad de Los Ángeles",
@@ -1490,7 +1377,6 @@
   },
   "help_online_more_county_resources_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "More county resources",
     "fr": "Plus de ressources du comté",
     "es": "Más recursos del condado",
@@ -1503,7 +1389,6 @@
   },
   "help_online_more_county_resources_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "<strong><a href=\"https://recovery.lacounty.gov/resources/\">LA County Recovers</a></strong> lists help from many county agencies. This includes help for:",
     "fr": "<strong><a href=\"https://recovery.lacounty.gov/resources/\">LA County Recovers</a></strong> liste les aides de nombreux agences du comté. Cela inclut des aides pour:",
     "es": "<strong><a href=\"https://recovery.lacounty.gov/resources/\">LA County Recovers</a></strong> enumera la asistencia que ofrecen muchas agencias del condado. Esto incluye asistencia para:",
@@ -1516,7 +1401,6 @@
   },
   "help_online_seniors": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Seniors",
     "fr": "Personnes âgées",
     "es": "personas mayores",
@@ -1529,7 +1413,6 @@
   },
   "help_online_disabled_people": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Disabled people",
     "fr": "Personnes handicapées",
     "es": "personas con discapacidad",
@@ -1542,7 +1425,6 @@
   },
   "help_online_animals": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Animals",
     "fr": "Animaux",
     "es": "animales",
@@ -1555,7 +1437,6 @@
   },
   "help_online_children": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Children",
     "fr": "Enfants",
     "es": "niños",
@@ -1568,7 +1449,6 @@
   },
   "help_online_mental_health": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Mental health",
     "fr": "Santé mentale",
     "es": "salud mental",
@@ -1581,7 +1461,6 @@
   },
   "help_online_much_more": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "And much more",
     "fr": "Et bien plus encore",
     "es": "y mucho más",
@@ -1594,7 +1473,6 @@
   },
   "help_online_language_note": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Information is written in English and Spanish.",
     "fr": "Les informations sont écrites en anglais et en espagnol.",
     "es": "La información está escrita en inglés y español.",
@@ -1607,7 +1485,6 @@
   },
   "help_online_salvation_army_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "The Salvation Army",
     "fr": "L'Armée du Salut",
     "es": "The Salvation Army",
@@ -1620,7 +1497,6 @@
   },
   "help_online_salvation_army_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "<strong>The Salvation Army</strong> gives disaster services to those affected by the fires. Visit their <a href=\"https://socal.salvationarmy.org/southern-california/disaster-services/\">Disaster Services</a> page or call <a href=\"tel:8007259005\">(800)725-9005</a>.",
     "fr": "<strong>L'Armée du Salut</strong> donne des services aux victimes des incendies. Visitez leur page <a href=\"https://socal.salvationarmy.org/southern-california/disaster-services/\">Services aux catastrophes</a> ou appeler <a href=\"tel:8007259005\">(800)725-9005</a>.",
     "es": "<strong>The Salvation Army</strong> ofrece servicios por catástrofes aquellos afectados por los incendios. Visite la página <a href=\"https://socal.salvationarmy.org/southern-california/disaster-services/\">de servicios en caso de catástrofes</a> o llame al <a href=\"tel:8007259005\">(800) 725-9005</a>.",
@@ -1634,7 +1510,6 @@
   "help_online_foreclosure_protection_title": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Foreclosure protection",
     "fr": "Protection contre la saisie immobilière",
     "es": "Protección contra ejecuciones hipotecarias",
@@ -1648,7 +1523,6 @@
   "help_online_foreclosure_protection_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "The U.S. Department of Housing and Urban Development (HUD) has stopped foreclosures for those affected by the fires. To qualify, your mortgage must be:",
     "fr": "Le Département américain du logement et du développement urbain (HUD) a arrêté les saisies immobilières pour les personnes touchées par les incendies. Pour être éligible, votre prêt hypothécaire doit être :",
     "es": "El Departamento de Vivienda y Desarrollo Urbano de EE. UU. (HUD) ha detenido las ejecuciones hipotecarias para los afectados por los incendios. Para calificar, su hipoteca debe ser:",
@@ -1662,7 +1536,6 @@
   "help_online_foreclosure_protection_list_1": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "For a single family, and",
     "fr": "Pour une famille unique, et",
     "es": "Para una familia individual, y",
@@ -1676,7 +1549,6 @@
   "help_online_foreclosure_protection_list_2": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "Insured by the Federal Housing Administration (FHA).",
     "fr": "Assuré par la Federal Housing Administration (FHA).",
     "es": "Asegurada por la Administración Federal de Vivienda (FHA).",
@@ -1691,7 +1563,6 @@
   "help_online_foreclosure_protection_description_2": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/get-help-online-shared.html",
     "en": "If you are facing foreclosure, contact your mortgage company. You may also call the FHA Resource Center at <a href=\"tel:8002255342\">(800) CALL-FHA.</a>",
     "fr": "Si vous êtes confronté à une saisie immobilière, contactez votre société de prêt hypothécaire. Vous pouvez également appeler le Centre de ressources de la FHA au <a href=\"tel:8002255342\">(800) CALL-FHA.</a>",
     "es": "Si se enfrenta a una ejecución hipotecaria, comuníquese con su compañía hipotecaria. También puede llamar al Centro de Recursos de la FHA al <a href=\"tel:8002255342\">(800) CALL-FHA.</a>",

--- a/src/_data/i18n/i18n-help-person.json
+++ b/src/_data/i18n/i18n-help-person.json
@@ -1,7 +1,6 @@
 {
   "help_person_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Get help in person",
     "fr": "Obtenir de l'aide en personne",
     "es": "Obtenga ayuda en persona",
@@ -14,7 +13,6 @@
   },
   "help_person_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "You can get help and advice in person at a Disaster Recovery Center.",
     "fr": "Vous pouvez obtenir de l'aide et des conseils en personne dans un centre de récupération des dommages.",
     "es": "Puede obtener ayuda en persona en un centro de recuperación por catástrofes",
@@ -27,7 +25,6 @@
   },
   "help_person_lead_text": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "You can get help and advice in person at a Disaster Recovery Center.",
     "fr": "Vous pouvez obtenir de l'aide et des conseils en personne dans un centre de récupération des dommages.",
     "es": "Puede obtener ayuda en persona en un centro de recuperación por catástrofes",
@@ -40,7 +37,6 @@
   },
   "help_person_plan_visit_button_text": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Plan your in-person visit",
     "fr": "Planifier votre visite en personne",
     "es": "Planee su visita en persona",
@@ -53,7 +49,6 @@
   },
   "help_person_find_a_drc": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Find a Disaster Recovery Center",
     "fr": "Trouver un centre de récupération des dommages",
     "es": "Encontrar un centro de recuperación por catástrofes",
@@ -66,7 +61,6 @@
   },
   "help_person_look_for_drc": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Look for the one nearest you on this map.",
     "fr": "Cherchez celui qui vous est le plus proche sur cette carte.",
     "es": "Busque el más cercano a usted en este mapa.",
@@ -79,7 +73,6 @@
   },
   "help_person_skip_map": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Skip map",
     "fr": "Passer la carte",
     "es": "Ignorar el mapa",
@@ -92,7 +85,6 @@
   },
   "help_person_directions_button_text": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Directions",
     "fr": "Directions",
     "es": "Indicaciones",
@@ -105,7 +97,6 @@
   },
   "help_person_ucla_drc_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "UCLA Disaster Recovery Center",
     "fr": "Centre de récupération des dommages de UCLA",
     "es": "Centro de recuperación por catástrofes de UCLA",
@@ -118,7 +109,6 @@
   },
   "help_person_ucla_drc_address": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "UCLA Research Park West<br />10850 West Pico Blvd.<br />Los Angeles, CA 90064",
     "fr": "UCLA Research Park West<br />10850 West Pico Blvd.<br />Los Angeles, CA 90064",
     "es": "UCLA Research Park West<br />10850 West Pico Blvd.<br />Los Angeles, CA 90064",
@@ -131,7 +121,6 @@
   },
   "help_person_altadena_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Altadena Disaster Recovery Center",
     "fr": "Centre de récupération des dommages d'Altadena",
     "es": "Centro de recuperación por catástrofes de Altadena",
@@ -144,7 +133,6 @@
   },
   "help_person_altadena_address": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "540 W. Woodbury Rd.<br />Altadena, CA 91001",
     "fr": "540 W. Woodbury Rd.<br />Altadena, CA 91001",
     "es": "540 W. Woodbury Road<br />Altadena, CA 91001",
@@ -159,7 +147,6 @@
   "help_person_hours_open": {
     "status": "ap_review",
     "comment": "original text was trunctated - machine translation used to repair",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "<strong>Hours open</strong>: Monday - Saturday, 9 am to 7 pm. Closed Sundays.",
     "fr": "<strong>Heures d'ouverture</strong>: Lundi - Samedi, 9h à 19h. Fermé le dimanche.",
     "es": "<strong>Horarios de disponibilidad</strong>: Lunes a sábado, 9 am a 7 pm. Cerrado los domingos.",
@@ -174,7 +161,6 @@
   "help_person_wait_times_alt": {
     "status": "ap_review",
     "comment": "machine translation used",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Bar chart showing the wait times for Los Angeles Disaster Recovery Centers. 12 pm to 3 pm are the busiest time with up to a 1 hour wait. 9 am, 5pm, and 6 pm are less busy. 7 pm to 8 pm tends not to have any wait.",
     "fr": "Graphique à barres montrant les temps d'attente pour les centres de récupération des dommages de Los Angeles. De 12h à 15h sont les heures les plus chargées avec jusqu'à 1 heure d'attente. 9h, 17h et 18h sont moins chargées. De 19h à 20h, il n'y a généralement pas d'attente.",
     "es": "Gráfico de barras que muestra los tiempos de espera en los centros de recuperación por catástrofes de Los Ángeles. De 12 p. m. a 3 p. m. es el horario más ocupado con hasta 1 hora de espera. A las 9 a. m., 5 p. m. y 6 p. m. hay menos gente. De 7 p. m. a 8 p. m. suele no haber espera.",
@@ -187,7 +173,6 @@
   },
   "help_person_wait_time": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Wait",
     "fr": "Attente",
     "es": "Espera",
@@ -200,7 +185,6 @@
   },
   "help_person_less_busy_wait_time_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Wait",
     "fr": "Attente",
     "es": "Espera",
@@ -213,7 +197,6 @@
   },
   "help_person_wait_times_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Wait times are approximate and can change quickly.",
     "fr": "Les temps d'attente sont approximatifs et peuvent changer rapidement.",
     "es": "Los tiempos de espera son aproximados y pueden cambiar rápidamente.",
@@ -226,7 +209,6 @@
   },
   "help_person_wait_times_description_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "The centers are busiest in the middle of the day. Come earlier or later to avoid waiting.",
     "fr": "Les centres sont les plus occupés au milieu de la journée. Venez plus tôt ou plus tard pour éviter l'attente.",
     "es": "Los centros están más ocupados a la mitad del día. Venga más temprano o más tarde para evitar esperar.",
@@ -239,7 +221,6 @@
   },
   "help_person_more_about_drcs": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "More about these centers:",
     "fr": "Plus d'informations sur ces centres:",
     "es": "Más información sobre estos centros:",
@@ -254,7 +235,6 @@
   "help_person_drcs_link_text": {
     "status": "ap_review",
     "comment": "machine translation used",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Los Angeles County Disaster Recovery Centers",
     "fr": "Centres de récupération des dommages de Los Angeles County",
     "es": "Centros de recuperación de daños de Los Angeles County",
@@ -267,7 +247,6 @@
   },
   "help_person_services_on_site": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Services on site",
     "fr": "Services sur site",
     "es": "Servicios en el sitio",
@@ -281,7 +260,6 @@
   "help_person_services_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Here are the services you can expect at the centers.",
     "fr": "Voici les services auxquels vous pouvez vous attendre dans les centres.",
     "es": "Estos son los servicios que puede esperar en los centros.",
@@ -294,7 +272,6 @@
   },
   "help_person_state_local_services": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "State and local services",
     "fr": "Services de l'État et locaux",
     "es": "Servicios estatales y locales",
@@ -308,7 +285,6 @@
   "help_person_sign_in_services": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "See a full list at",
     "fr": "Voir une liste complète à",
     "es": "Ver una lista completa en",
@@ -322,7 +298,6 @@
   "help_person_food": {
     "status": "ap_review",
     "comment": "machine translation used",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Food benefits",
     "fr": "Avantages alimentaires",
     "es": "beneficios alimentarios",
@@ -335,7 +310,6 @@
   },
   "help_person_health_services": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Health services and advice",
     "fr": "Services de santé et conseils",
     "es": "servicios y consejos de salud",
@@ -349,7 +323,6 @@
   "help_person_mental_health_services": {
     "status": "ap_review",
     "comment": "machine translation used",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Mental health services",
     "fr": "Services de santé mentale et conseils",
     "es": "servicios y consejos de salud mental",
@@ -362,7 +335,6 @@
   },
   "help_person_unemployment": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Unemployment",
     "fr": "Chômage",
     "es": "desempleo",
@@ -375,7 +347,6 @@
   },
   "help_person_disability_benefits": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Disability benefits",
     "fr": "Avantages pour personnes handicapées",
     "es": "beneficios por discapacidad",
@@ -388,7 +359,6 @@
   },
   "help_person_replacing_personal_documents": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Replacing personal documents",
     "fr": "Remplacement de documents personnels",
     "es": "sustitución de documentos personales",
@@ -401,7 +371,6 @@
   },
   "help_person_tips_for_hiring_contractors": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Tips for hiring contractors",
     "fr": "Conseils pour embaucher des entrepreneurs",
     "es": "consejos para emplear contratistas",
@@ -414,7 +383,6 @@
   },
   "help_person_help_with_insurance_claims": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Help with insurance claims",
     "fr": "Aide avec les réclamations d'assurance",
     "es": "ayuda con las reclamaciones del seguro",
@@ -427,7 +395,6 @@
   },
   "help_person_tax_help_and_relief": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Tax help and relief",
     "fr": "Aide fiscale et relèvement",
     "es": "ayuda y asistencia fiscal",
@@ -441,7 +408,6 @@
 
   "help_person_before_you_arrive": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Before you arrive",
     "fr": "Avant votre arrivée",
     "es": "Antes de llegar",
@@ -454,7 +420,6 @@
   },
   "help_person_before_you_arrive_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Use our checklist to <a href=\"/lafires/plan-your-in-person-visit/\">plan your in-person visit</a>.",
     "fr": "Utilisez notre checklist pour <a href=\"/lafires/fr/plan-your-in-person-visit/\">planifier votre visite en personne</a>.",
     "es": "Use nuestra lista para <a href=\"/lafires/es/plan-your-in-person-visit/\">planificar su consulta en persona</a>.",
@@ -468,7 +433,6 @@
   },
   "help_person_bring_items": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "If you can, bring these items with you",
     "fr": "Si vous le pouvez, emportez ces articles avec vous",
     "es": "Si puede, lleve estos artículos:",
@@ -482,7 +446,6 @@
   "help_person_items_address_damaged_home": {
     "status": "ap_review",
     "comment": "machine translation used",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Address of the damaged primary home",
     "fr": "Adresse de la maison principale endommagée",
     "es": "Dirección de la casa principal dañada",
@@ -495,7 +458,6 @@
   },
   "help_person_insurance_coverage_information": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Insurance coverage information",
     "fr": "Informations sur la couverture d'assurance",
     "es": "información sobre la cobertura del seguro",
@@ -508,7 +470,6 @@
   },
   "help_person_current_phone_number_and_mailing_address": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Current phone number and mailing address",
     "fr": "Numéro de téléphone actuel et adresse de messagerie",
     "es": "número de teléfono y dirección postal actuales",
@@ -521,7 +482,6 @@
   },
   "help_person_bank_account_information": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Bank account information",
     "fr": "Informations sur le compte bancaire",
     "es": "información de la cuenta bancaria",
@@ -534,7 +494,6 @@
   },
   "help_person_when_you_get_here": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "When you get here",
     "fr": "Lorsque vous arrivez",
     "es": "Cuando llegue aquí:",
@@ -548,7 +507,6 @@
   "help_person_arrival_info_parking": {
     "status": "ap_review",
     "comment": "machine translation used",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "<strong>Parking: </strong>Free parking available. People may be there to direct you.",
     "fr": "<strong>Parking: </strong>Parking gratuit disponible. Des personnes peuvent être là pour vous diriger.",
     "es": "<strong>Parking: </strong>Parking gratuito disponible. Las personas pueden estar allí para guiarte.",
@@ -562,7 +520,6 @@
   "help_person_sign_in_info": {
     "status": "ap_review",
     "comment": "machine translation used, original was truncated",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "<strong>Sign in: </strong>Sign in at FEMA tents for federal benefits, or go into the building for state and local services.",
     "fr": "<strong>S'inscrire: </strong>Inscrivez-vous aux tentes FEMA pour les prestations fédérales, ou entrez dans le bâtiment pour les services étatiques et locaux.",
     "es": "<strong>Regístrese: </strong>Regístrese en las carpas de FEMA para beneficios federales, o entre al edificio para servicios estatales y locales.",
@@ -575,7 +532,6 @@
   },
   "help_person_restrooms_and_beverages": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Restrooms and beverages available.",
     "fr": "Toilettes et boissons disponibles.",
     "es": "Hay baños y bebidas disponibles.",
@@ -588,7 +544,6 @@
   },
   "help_person_use_plan_your_visit": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/get-help-in-person-shared.html",
     "en": "Use <a href=\"/lafires/plan-your-in-person-visit/\">Plan your in-person visit</a> to help you find the services you need.",
     "fr": "Utilisez <a href=\"/lafires/fr/plan-your-in-person-visit/\">Plan your in-person visit</a> pour vous aider à trouver les services dont vous avez besoin.",
     "es": "Utilice <a href=\"/lafires/es/plan-your-in-person-visit/\">plan de su visita en persona</a> para ayudarle a encontrar los servicios que necesita.",

--- a/src/_data/i18n/i18n-home.json
+++ b/src/_data/i18n/i18n-home.json
@@ -1,7 +1,6 @@
 {
   "home_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "2025 Los Angeles Fires",
     "fr": "Feux de Los Angeles en 2025",
     "es": "Incendios de Los Ángeles en 2025",
@@ -14,7 +13,6 @@
   },
   "home_breadcrumbparent": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Home",
     "fr": "Accueil",
     "es": "Inicio",
@@ -27,7 +25,6 @@
   },
   "home_category1": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "LA Fires",
     "fr": "Feux de Los Angeles",
     "es": "Incendios de Los Ángeles",
@@ -40,7 +37,6 @@
   },
   "home_category2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Top Story",
     "fr": "Top Story",
     "es": "Noticia principal",
@@ -53,7 +49,6 @@
   },
   "home_category3": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Public Safety",
     "fr": "Public Safety",
     "es": "Seguridad pública",
@@ -66,7 +61,6 @@
   },
   "home_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Help and info for people affected by the 2025 Los Angeles County fires.",
     "fr": "Aide et informations pour les personnes affectées par les feux de Los Angeles County en 2025.",
     "es": "Ayuda e información para las personas afectadas por los incendios del condado de Los Ángeles (LA) de 2025",
@@ -79,7 +73,6 @@
   },
   "home_keywords": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "California, government, LA, Los Angeles, fires, wildfires",
     "fr": "Californie, gouvernement, LA, Los Angeles, feux, feux de forêt",
     "es": "California, gobierno, LA, Los Ángeles, incendios, incendios forestales",
@@ -92,7 +85,6 @@
   },
   "home_main_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "2025 Los Angeles Fires",
     "fr": "Feux de Los Angeles en 2025",
     "es": "Incendios de Los Ángeles en 2025",
@@ -105,7 +97,6 @@
   },
   "home_main_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Help and info for people affected by the wildfires",
     "fr": "Aide et informations pour les personnes affectées par les feux de forêt",
     "es": "Ayuda e información para las personas afectadas por los incendios forestales",
@@ -118,7 +109,6 @@
   },
   "home_find_help_available_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Find help available to you",
     "fr": "Trouvez l'aide disponible pour vous",
     "es": "Encuentre ayuda disponible para usted",
@@ -131,7 +121,6 @@
   },
   "home_track_la_progress_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Track LA’s progress",
     "fr": "Suivez le progrès de Los Angeles",
     "es": "Siga el progreso de LA",
@@ -144,7 +133,6 @@
   },
   "home_top_needs": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Top needs",
     "fr": "Top besoins",
     "es": "Necesidades principales",
@@ -158,7 +146,6 @@
   "home_hands_reaching_out_image_alt": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Hands reaching out to help line art background image",
     "fr": "Image de fond en ligne de mains qui atteignent pour aider",
     "es": "Imagen de fondo de líneas de manos que se extienden para ayudar",
@@ -171,7 +158,6 @@
   },
   "home_stay_healthy": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Stay healthy",
     "fr": "Restez en santé",
     "es": "Mantenerse saludable",
@@ -184,7 +170,6 @@
   },
   "home_replace_documents": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Replace documents",
     "fr": "Remplacer les documents",
     "es": "Reemplazar documentos",
@@ -197,7 +182,6 @@
   },
   "home_get_debris_removed": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Get debris removed",
     "fr": "Obtenir le débris enlevé",
     "es": "Solicitar remoción de escombros",
@@ -211,7 +195,6 @@
   "home_upcoming_deadlines": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Deadlines",
     "fr": "Délais",
     "es": "Plazos",
@@ -224,7 +207,6 @@
   },
   "home_march_31_2025": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "March 31, 2025",
     "fr": "31 mars 2025",
     "es": "31 de marzo de 2025",
@@ -237,7 +219,6 @@
   },
   "home_april_15_2025": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "April 15, 2025",
     "fr": "15 avril 2025",
     "es": "15 de abril de 2025",
@@ -251,7 +232,6 @@
   "home_apply_for_fema_individual_assistance": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "To apply for <a href=\"http://disasterassistance.gov\">FEMA Individual Assistance</a>",
     "fr": "Pour appliquer pour <a href=\"http://disasterassistance.gov\">l'Aide individuelle FEMA</a>",
     "es": "Para solicitar <a href=\"http://disasterassistance.gov\">asistencia individual de la Agencia Federal para el Manejo de Emergencias (FEMA)</a>",
@@ -266,7 +246,6 @@
   "home_apply_for_sba_business_loan": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "To apply for an <a href=\"https://www.sba.gov/funding-programs/disaster-assistance/california-wildfires\">SBA business loan</a>",
     "fr": "Pour appliquer pour un <a href=\"https://www.sba.gov/funding-programs/disaster-assistance/california-wildfires\">prêt d'entreprise SBA</a>",
     "es": "Para solicitar un <a href=\"https://www.sba.gov/funding-programs/disaster-assistance/california-wildfires\">crédito comercial de la Agencia Federal de Pequeños Negocios (SBA)</a>",
@@ -281,7 +260,6 @@
   "home_opt_in_for_free_debris_removal": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "To opt in for <a href=\"https://recovery.lacounty.gov/debris-removal/roe/\">free debris removal</a>",
     "fr": "Pour s'inscrire à <a href=\"https://recovery.lacounty.gov/debris-removal/roe/\">l'enlèvement gratuit des débris</a>",
     "es": "Para optar por la <a href=\"https://recovery.lacounty.gov/debris-removal/roe/\">remoción gratuita</a>",
@@ -295,7 +273,6 @@
   },
   "home_what_you_can_do": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "What you can do",
     "fr": "Ce que vous pouvez faire",
     "es": "Lo que puede hacer",
@@ -308,7 +285,6 @@
   },
   "home_help_online_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Get help online",
     "fr": "Obtenir de l'aide en ligne",
     "es": "Obtenga ayuda en línea",
@@ -321,7 +297,6 @@
   },
   "home_help_online_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "We can help you with food, expenses, shelter, and more.",
     "fr": "Nous pouvons vous aider avec de la nourriture, les dépenses, le logement et plus encore.",
     "es": "Podemos ayudarle con alimentos, gastos, alojamiento y mucho más.",
@@ -334,7 +309,6 @@
   },
   "home_help_in_person_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Get help in person",
     "fr": "Obtenir de l'aide en personne",
     "es": "Obtenga ayuda en persona",
@@ -348,7 +322,6 @@
   "home_help_in_person_description": {
     "status": "ap_review",
     "comment": "Edited for title consistency",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Disaster Recovery Centers are open in Altadena and UCLA Research Park West.",
     "fr": "Les Disaster Recovery Centers sont ouverts à Altadena et UCLA Research Park West.",
     "es": "Los Disaster Recovery Centers están abiertos en Altadena y UCLA Research Park West.",
@@ -361,7 +334,6 @@
   },
   "home_see_real_time_info": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "See real-time info",
     "fr": "Voir les informations en temps réel",
     "es": "Vea información en tiempo real",
@@ -374,7 +346,6 @@
   },
   "home_find_fire_maps_air_quality_and_road_closure_maps": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Find fire maps, air quality information, and road closure maps.",
     "fr": "Trouvez les cartes de feux, les informations sur la qualité de l'air et les cartes de fermeture des routes.",
     "es": "Encuentre mapas de incendios, información sobre la calidad del aire y los mapas de cierres viales.",
@@ -387,7 +358,6 @@
   },
   "home_start_your_recovery": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Start your recovery",
     "fr": "Commencer votre récupération",
     "es": "Comience la recuperación",
@@ -400,7 +370,6 @@
   },
   "home_learn_when_you_can_return_home_and_how_to_start_recovering": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Learn when you can return home and how to start recovering.",
     "fr": "Apprenez quand vous pouvez retourner à la maison et comment commencer à récupérer.",
     "es": "Sepa cuándo puede regresar a casa y cómo empezar a recuperarse.",
@@ -413,7 +382,6 @@
   },
   "home_help_business_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Help your business",
     "fr": "Aider votre entreprise",
     "es": "Ayuda para su negocio",
@@ -426,7 +394,6 @@
   },
   "home_businesses_affected_by_the_fires_can_get_tax_relief_and_extensions": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Businesses affected by the fires can get tax relief and extensions.",
     "fr": "Les entreprises affectées par les feux peuvent obtenir des exonérations fiscales et des extensions.",
     "es": "Las empresas afectadas por los incendios pueden obtener alivio fiscal y extensiones.",
@@ -439,7 +406,6 @@
   },
   "home_volunteer": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Volunteer",
     "fr": "Volontaire",
     "es": "Ser voluntario",
@@ -452,7 +418,6 @@
   },
   "home_give_time_or_money_to_help_people_affected_by_the_fires": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Give time or money to help people affected by the fires.",
     "fr": "Donnez du temps ou de l'argent pour aider les personnes affectées par les feux.",
     "es": "Dar tiempo o dinero para ayudar a las personas afectadas por los incendios.",
@@ -465,7 +430,6 @@
   },
   "home_services_finder_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Recovery services finder",
     "fr": "Recherche de services de récupération",
     "es": "Buscador de servicios de recuperación",
@@ -478,7 +442,6 @@
   },
   "home_services_finder_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Don’t know where to start? Use our finder to see what recovery help is available to you.",
     "fr": "Ne savez pas par où commencer ? Utilisez notre recherche pour voir quelles aides de récupération sont disponibles pour vous.",
     "es": "¿No sabe por dónde comenzar? Use nuestro buscador para ver qué ayuda de recuperación está disponible para usted.",
@@ -491,7 +454,6 @@
   },
   "home_help_us_improve": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Help us improve",
     "fr": "Aidez-nous à améliorer",
     "es": "Ayudarnos a mejorar",
@@ -504,7 +466,6 @@
   },
   "home_tell_us_what_this_website_could_do_better": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Tell us what this website could do better. Take this <a href=\"https://www.surveymonkey.com/r/2025LAFireStateResponse\">3-minute survey</a>. You can take it in English or <a href=\"https://www.surveymonkey.com/r/2025LAFireStateResponse?lang=es\">Spanish</a>.",
     "fr": "Dites-nous ce que ce site web pourrait faire mieux. Faites ce <a href=\"https://www.surveymonkey.com/r/2025LAFireStateResponse\">enquête de 3 minutes</a>. Vous pouvez le faire en anglais ou <a href=\"https://www.surveymonkey.com/r/2025LAFireStateResponse?lang=es\">en espagnol</a>.",
     "es": "Díganos lo que esta página web podría mejorar. Conteste esta <a href=\"https://www.surveymonkey.com/r/2025LAFireStateResponse\">encuesta de 3 minutos</a>. Puede contestarla en inglés o en <a href=\"https://www.surveymonkey.com/r/2025LAFireStateResponse?lang=es\">español</a>.",
@@ -517,7 +478,6 @@
   },
   "home_join_the_conversation": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Join the conversation",
     "fr": "Rejoignez la conversation",
     "es": "Unirse a la conversación",
@@ -530,7 +490,6 @@
   },
   "home_sign_up_to_tell_us_about_your_recovery_experience_and_hear_from_others": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "<a href=\"https://engaged.ca.gov/\">Sign up</a> to tell us about your recovery experience and hear from others.",
     "fr": "<a href=\"https://engaged.ca.gov/\">S'inscrire</a> pour nous parler de votre expérience de récupération et entendre parler d'autres personnes.",
     "es": "<a href=\"https://engaged.ca.gov/\">Regístrese</a> para contarnos sobre su experiencia de recuperación y conocer noticias de otras personas.",
@@ -543,7 +502,6 @@
   },
   "home_state_updates": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "State updates",
     "fr": "Mises à jour de l'État",
     "es": "Actualizaciones estatales",
@@ -557,7 +515,6 @@
   "home_view_all_la_fires_news": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "View all LA fires news",
     "fr": "Voir toutes les nouvelles des feux de Los Angeles",
     "es": "Ver todas las noticias sobre los incendios de Los Ángeles",
@@ -570,7 +527,6 @@
   },
   "home_rebuild_faster_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Rebuild - faster",
     "fr": "Reconstruire - plus rapidement",
     "es": "Reconstruir más rápido",
@@ -583,7 +539,6 @@
   },
   "home_rebuild_faster_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Governor Newsom <a href=\"https://www.gov.ca.gov/2025/01/12/governor-newsom-signs-executive-order-to-help-los-angeles-rebuild-faster-and-stronger/\">suspended permit and review requirements</a> under the California Environmental Quality Act (CEQA) and the California Coastal Act. This allows victims of the recent fires to restore their homes and businesses faster.",
     "fr": "Le gouverneur Newsom a suspendu les exigences de permis et de révision sous le California Environmental Quality Act (CEQA) et le California Coastal Act. Cela permet aux victimes des feux récents de restaurer leurs maisons et leurs entreprises plus rapidement.",
     "es": "El gobernador Newsom <a href=\"https://www.gov.ca.gov/2025/01/12/governor-newsom-signs-executive-order-to-help-los-angeles-rebuild-faster-and-stronger/\">suspendió los requisitos de permisos y revisiones</a> según la Ley de Calidad Ambiental de California (California Environmental Quality Act, CEQA) y la Ley Costera de California. Esto permite que las personas afectadas por los incendios recientes reconstruyan sus casas y empresas más rápido.",
@@ -597,7 +552,6 @@
   },
   "home_governor_signs_legislation": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "The Governor <a href=\"https://www.gov.ca.gov/2025/01/23/governor-newsom-signs-2-5-billion-bipartisan-relief-package-to-help-los-angeles-recover-and-rebuild-faster-from-firestorm/\">signed legislation</a> providing $2.5 billion in immediate disaster relief. This supports response and recovery efforts.",
     "fr": "Le gouverneur a signé une législation <a href=\"https://www.gov.ca.gov/2025/01/23/governor-newsom-signs-2-5-billion-bipartisan-relief-package-to-help-los-angeles-recover-and-rebuild-faster-from-firestorm/\">fournissant 2,5 milliards de dollars en aide aux victimes des feux</a>. Cela soutient les efforts de réponse et de récupération.",
     "es": "El gobernador <a href=\"https://www.gov.ca.gov/2025/01/23/governor-newsom-signs-2-5-billion-bipartisan-relief-package-to-help-los-angeles-recover-and-rebuild-faster-from-firestorm/\">firmó la legislación</a> para proporcionar $2.5 mil millones en subsidio inmediato por catástrofes. Esto respalda los esfuerzos de respuesta y recuperación.",
@@ -611,7 +565,6 @@
   },
   "home_see_all_actions": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "See all the <a href=\"https://www.gov.ca.gov/2025/01/24/heres-all-the-actions-governor-newsom-has-taken-in-response-to-the-los-angeles-fires/\">Governor's actions in response to the fires</a>.",
     "fr": "Voir toutes les <a href=\"https://www.gov.ca.gov/2025/01/24/heres-all-the-actions-governor-newsom-has-taken-in-response-to-the-los-angeles-fires/\">actions du gouverneur en réponse aux feux</a>.",
     "es": "Vea todas las <a href=\"https://www.gov.ca.gov/2025/01/24/heres-all-the-actions-governor-newsom-has-taken-in-response-to-the-los-angeles-fires/\">acciones del gobernador en respuesta a los incendios</a>.",
@@ -625,7 +578,6 @@
   },
   "home_major_disaster_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Major Disaster Declaration",
     "fr": "Déclaration de catastrophe majeure",
     "es": "Declaración de catástrofe importante",
@@ -638,7 +590,6 @@
   },
   "home_major_disaster_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "On January 8, California got a <a href=\"https://www.fema.gov/press-release/20250109/president-joseph-r-biden-jr-approves-major-disaster-declaration-california#:~:text=Learn%20more-,President%20Joseph%20R.%20Biden%2C%20Jr.,Major%20Disaster%20Declaration%20for%20California&text=WASHINGTON%20%2D%2D%20FEMA%20announced%20that,7%2C%202025%2C%20and%20continuing.\">Major Disaster Declaration</a> for the California wildfires. This lets federal agencies give aid and resources for recovery in the affected areas.",
     "fr": "Le 8 janvier, Californie a obtenu une <a href=\"https://www.fema.gov/press-release/20250109/president-joseph-r-biden-jr-approves-major-disaster-declaration-california#:~:text=Learn%20more-,President%20Joseph%20R.%20Biden%2C%20Jr.,Major%20Disaster%20Declaration%20for%20California&text=WASHINGTON%20%2D%2D%20FEMA%20announced%20that,7%2C%202025%2C%20and%20continuing.\">Déclaration de catastrophe majeure</a> pour les feux de forêt de Californie. Cela permet aux agences fédérales de donner de l'aide et des ressources pour la récupération dans les zones affectées.",
     "es": "El 8 de enero, California hizo una <a href=\"https://www.fema.gov/press-release/20250109/president-joseph-r-biden-jr-approves-major-disaster-declaration-california#:~:text=Learn%20more-,President%20Joseph%20R.%20Biden%2C%20Jr.,Major%20Disaster%20Declaration%20for%20California&text=WASHINGTON%20%2D%2D%20FEMA%20announced%20that,7%2C%202025%2C%20and%20continuing.\">declaración de catástrofe importante</a> por los incendios forestales. Esto permite a las agencias federales dar ayuda y recursos para la recuperación en las áreas afectadas.",
@@ -652,7 +603,6 @@
   },
   "home_declaration_assistance": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "Through this declaration from President Biden, California gets assistance for",
     "fr": "Grâce à cette déclaration du président Biden, Californie obtient de l'aide pour",
     "es": "Mediante esta declaración del presidente Biden, California obtiene asistencia para:",
@@ -665,7 +615,6 @@
   },
   "home_assistance_list_1": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "individuals,",
     "fr": "des individus,",
     "es": "las personas,",
@@ -678,7 +627,6 @@
   },
   "home_assistance_list_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "the public, and",
     "fr": "le public, et",
     "es": "el público, y",
@@ -691,7 +639,6 @@
   },
   "home_assistance_list_3": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/index-shared.html",
     "en": "small businesses.",
     "fr": "les petites entreprises.",
     "es": "las pequeñas empresas.",

--- a/src/_data/i18n/i18n-plan-visit.json
+++ b/src/_data/i18n/i18n-plan-visit.json
@@ -1,7 +1,6 @@
 {
   "plan_visit_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Plan your in-person visit",
     "fr": "Planifier votre visite en personne",
     "es": "Planee su visita en persona",
@@ -14,7 +13,6 @@
   },
   "plan_visit_breadcrumb_parent": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get help in person",
     "fr": "Obtenir de l'aide en personne",
     "es": "Obtenga ayuda en persona",
@@ -27,7 +25,6 @@
   },
   "plan_visit_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Use this checklist to find the resources you need at a Disaster Recovery Center. It covers the most common services.",
     "fr": "Utilisez ce formulaire pour trouver les ressources dont vous avez besoin au centre de récupération des dommages. Il couvre les services les plus courants.",
     "es": "Use esta lista para encontrar los recursos que necesita en un centro de recuperación por catástrofes. Enumera los servicios más comunes.",
@@ -40,7 +37,6 @@
   },
   "plan_visit_share_button": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Share",
     "fr": "Partager",
     "es": "Compartir",
@@ -54,7 +50,6 @@
   "plan_visit_share_aria_label": {
     "status": "ap_review",
     "comment": "Machine translated aria label",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Share checklist",
     "fr": "Partager le formulaire",
     "es": "Compartir el formulario",
@@ -67,7 +62,6 @@
   },
   "plan_visit_english_pdf": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "English PDF",
     "fr": "PDF en anglais",
     "es": "PDF en inglés",
@@ -80,7 +74,6 @@
   },
   "plan_visit_more_languages": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "More languages",
     "fr": "Plus de langues",
     "es": "Más idiomas",
@@ -93,7 +86,6 @@
   },
   "plan_visit_spanish_pdf": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Español (Spanish) PDF",
     "fr": "PDF en espagnol",
     "es": "PDF en español",
@@ -106,7 +98,6 @@
   },
   "plan_visit_chinese_simplified_pdf": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "简体中文 (Simplified Chinese) PDF",
     "fr": "PDF en chinois simplifié",
     "es": "简体中文 (PDF en chino simplificado)",
@@ -119,7 +110,6 @@
   },
   "plan_visit_chinese_traditional_pdf": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "繁體中文 (Traditional Chinese) PDF",
     "fr": "PDF en chinois traditionnel",
     "es": "繁體 (PDF en chino tradicional)",
@@ -132,7 +122,6 @@
   },
   "plan_visit_tagalog_pdf": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Tagalog (Filipino) PDF",
     "fr": "PDF en tagalog",
     "es": "PDF en tagalog",
@@ -145,7 +134,6 @@
   },
   "plan_visit_vietnamese_pdf": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Việt (Vietnamese) PDF",
     "fr": "PDF en vietnamien",
     "es": "PDF en vietnamita",
@@ -158,7 +146,6 @@
   },
   "plan_visit_korean_pdf": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "한국인 (Korean) PDF",
     "fr": "PDF en coréen",
     "es": "한국인 (PDF en coreano)",
@@ -171,7 +158,6 @@
   },
   "plan_visit_health_section": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Health",
     "fr": "Santé",
     "es": "Salud",
@@ -184,7 +170,6 @@
   },
   "plan_visit_health_wildfire": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Find out how to stay healthy during a wildfire",
     "fr": "Découvrez comment rester en bonne santé pendant un incendie de forêt",
     "es": "Aprenda cómo mantenerse saludable durante un incendio forestal",
@@ -197,7 +182,6 @@
   },
   "plan_visit_health_wildfire_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "California Department of Public Health (CDPH)",
     "fr": "Département de la santé publique de Californie (CDPH)",
     "es": "Departamento de Salud Pública de California (California Department of Public Health, CDPH)",
@@ -210,7 +194,6 @@
   },
   "plan_visit_health_n95": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get N95s and public health information",
     "fr": "Obtenir des N95 et des informations sur la santé publique",
     "es": "Obtener cubrebocas N95 e información de salud pública",
@@ -223,7 +206,6 @@
   },
   "plan_visit_health_n95_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County Department of Public Health, Environmental Health Division (DPH)",
     "fr": "Département de la santé publique de Los Angeles, Division de l'hygiène environnementale (DPH)",
     "es": "Departamento de Salud Pública (Department of Public Health, DPH) del condado de Los Ángeles, División de Salud Ambiental",
@@ -236,7 +218,6 @@
   },
   "plan_visit_health_medical": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get help accessing medical services",
     "fr": "Obtenir de l'aide pour accéder aux services médicaux",
     "es": "Obtener ayuda para acceder a los servicios médicos:",
@@ -249,7 +230,6 @@
   },
   "plan_visit_health_medical_prescription": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Prescription medication refills",
     "fr": "Remplissage de médicaments de prescription",
     "es": "resurtir sus medicamentos recetados",
@@ -262,7 +242,6 @@
   },
   "plan_visit_health_medical_referrals": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Service referrals",
     "fr": "Références de services",
     "es": "referencias de servicio",
@@ -275,7 +254,6 @@
   },
   "plan_visit_health_medical_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County Department of Public Health, Medication Assistance (DPH)",
     "fr": "Département de la santé publique de Los Angeles, Assistance médicamentaire (DPH)",
     "es": "Asistencia con Medicamentos del Departamento de Salud Pública (DPH) del condado de Los Ángeles",
@@ -288,7 +266,6 @@
   },
   "plan_visit_health_medical_cal": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get Medi-Cal",
     "fr": "Obtenir Medi-Cal",
     "es": "Obtener Medi-Cal",
@@ -301,7 +278,6 @@
   },
   "plan_visit_health_medical_cal_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County Department of Public Social Services (DPSS)",
     "fr": "Département de la santé publique de Los Angeles, Services sociaux (DPSS)",
     "es": "Departamento de Servicios Sociales Públicos (Department of Public Social Services, DPSS) del condado de Los Ángeles",
@@ -314,7 +290,6 @@
   },
   "plan_visit_health_mental": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get help with mental health resources",
     "fr": "Obtenir de l'aide pour les ressources de santé mentale",
     "es": "Obtenga ayuda con los recursos de salud mental",
@@ -327,7 +302,6 @@
   },
   "plan_visit_health_mental_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County Department of Mental Health (DMH)",
     "fr": "Département de la santé mentale de Los Angeles (DMH)",
     "es": "Departamento de Salud Mental (Department of Mental Health, DMH) del condado de Los Ángeles",
@@ -340,7 +314,6 @@
   },
   "plan_visit_health_disabilities": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get help for people who are older or have disabilities",
     "fr": "Obtenir de l'aide pour les personnes âgées ou handicapées",
     "es": "Obtenga ayuda para las personas mayores o personas con discapacidad:",
@@ -353,7 +326,6 @@
   },
   "plan_visit_health_disabilities_referrals": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Service referrals",
     "fr": "Références de services",
     "es": "referencias de servicio",
@@ -366,7 +338,6 @@
   },
   "plan_visit_health_disabilities_caregiver": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Caregiver support",
     "fr": "Support pour les soignants",
     "es": "apoyo para cuidadores",
@@ -379,7 +350,6 @@
   },
   "plan_visit_health_disabilities_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County Aging & Disabilities Department (AD)",
     "fr": "Département des soins aux personnes âgées et aux personnes handicapées de Los Angeles (AD)",
     "es": "Departamento para Adultos Mayores y Personas con Discapacidad (Aging & Disabilities, AD) del condado de Los Ángeles",
@@ -392,7 +362,6 @@
   },
   "plan_visit_health_veterans": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get long-term care for veterans and spouses",
     "fr": "Obtenir des soins à long terme pour les vétérans et leurs conjoints",
     "es": "Obtener atención a largo plazo para veteranos y sus cónyuges",
@@ -405,7 +374,6 @@
   },
   "plan_visit_health_veterans_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "California Veterans Affairs (CalVet)",
     "fr": "Département des affaires des vétérans de Californie (CalVet)",
     "es": "Asuntos de Veteranos de California (California Veterans Affairs, CalVet)",
@@ -418,7 +386,6 @@
   },
   "plan_visit_food_section": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Food",
     "fr": "Alimentation",
     "es": "Alimentos",
@@ -431,7 +398,6 @@
   },
   "plan_visit_food_benefits": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get food benefits",
     "fr": "Obtenir des avantages alimentaires",
     "es": "Obtenga asistencia para alimentos",
@@ -444,7 +410,6 @@
   },
   "plan_visit_food_benefits_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County Department of Public Social Services (DPSS)",
     "fr": "Département des services sociaux de Los Angeles (DPSS)",
     "es": "Departamento de Servicios Sociales Públicos (DPSS) del condado de Los Ángeles",
@@ -457,7 +422,6 @@
   },
   "plan_visit_food_wic": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get food benefits for women and children (WIC)",
     "fr": "Obtenir des avantages alimentaires pour les femmes et les enfants (WIC)",
     "es": "Obtener beneficios del Programa de Nutrición Suplementaria Especial para Mujeres, Bebés y Niños (Women, Infants, and Children, WIC)",
@@ -470,7 +434,6 @@
   },
   "plan_visit_food_wic_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "California Department of Public Health (CDPH)",
     "fr": "Département de la santé publique de Californie (CDPH)",
     "es": "Departamento de Salud Pública de California (CDPH)",
@@ -483,7 +446,6 @@
   },
   "plan_visit_housing_section": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Housing",
     "fr": "Logement",
     "es": "Vivienda",
@@ -496,7 +458,6 @@
   },
   "plan_visit_housing_help": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get help with housing",
     "fr": "Obtenir de l'aide avec le logement",
     "es": "Obtenga ayuda con la vivienda",
@@ -509,7 +470,6 @@
   },
   "plan_visit_housing_help_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County 211",
     "fr": "LA County 211",
     "es": "LA County 211",
@@ -523,7 +483,6 @@
   "plan_visit_housing_temporary": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Find temporary housing",
     "fr": "Trouver un logement provisoire",
     "es": "Encontrar alojamiento temporal",
@@ -537,7 +496,6 @@
   "plan_visit_housing_temporary_agency": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County Department of Public Social Services (DPSS)",
     "fr": "Département des services sociaux de Los Angeles (DPSS)",
     "es": "Departamento de Servicios Sociales Públicos (DPSS) del condado de Los Ángeles",
@@ -550,7 +508,6 @@
   },
   "plan_visit_housing_protections": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get help with housing protections",
     "fr": "Obtenir de l'aide avec les protections du logement",
     "es": "Obtenga ayuda con la protección de vivienda:",
@@ -563,7 +520,6 @@
   },
   "plan_visit_housing_protections_gouging": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Price gouging",
     "fr": "Surtaxe",
     "es": "alza de precios",
@@ -576,7 +532,6 @@
   },
   "plan_visit_housing_protections_tenant": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Housing and tenant protections",
     "fr": "Protection du logement et des locataires",
     "es": "protección para viviendas e inquilinos",
@@ -589,7 +544,6 @@
   },
   "plan_visit_housing_protections_foreclosure": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Foreclosure prevention",
     "fr": "Prévention des saisies",
     "es": "prevención de ejecución hipotecaria",
@@ -602,7 +556,6 @@
   },
   "plan_visit_housing_protections_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County Department of Consumer & Business Affairs (DCBA)",
     "fr": "Département des affaires du consommateur et de la vente de Los Angeles (DCBA)",
     "es": "Departamento de Asuntos de Empresas y Consumidores (Department of Consumer and Business Affairs, DCBA) del condado de Los Ángeles",
@@ -615,7 +568,6 @@
   },
   "plan_visit_social_services_section": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Social services",
     "fr": "Services sociaux",
     "es": "Servicios sociales",
@@ -628,7 +580,6 @@
   },
   "plan_visit_social_services_child_support": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get help with child support questions",
     "fr": "Obtenir de l'aide avec les questions relatives au soutien financier",
     "es": "Obtenga ayuda con las preguntas sobre la manutención infantil",
@@ -641,7 +592,6 @@
   },
   "plan_visit_social_services_child_support_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County Child Support Services Department (CSSD)",
     "fr": "Département des services de soutien financier des enfants de Los Angeles (CSSD)",
     "es": "Departamento de Servicios de Manutención Infantil (Child Support Services Department, CSSD) del condado de Los Ángeles",
@@ -654,7 +604,6 @@
   },
   "plan_visit_social_services_va": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get VA benefits",
     "fr": "Obtenir des avantages VA",
     "es": "Obtenga asistencia para veteranos",
@@ -667,7 +616,6 @@
   },
   "plan_visit_social_services_va_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "California Veterans Affairs (CalVet)",
     "fr": "Département des affaires des vétérans de Californie (CalVet)",
     "es": "Asuntos de Veteranos de California (CalVet)",
@@ -681,7 +629,6 @@
   "plan_visit_fema_section": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Individual assistance",
     "fr": "Aide individuelle",
     "es": "Ayuda individual",
@@ -694,7 +641,6 @@
   },
   "plan_visit_fema_grants": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get Individual and Household Program grant extensions (State Supplemental Grant Program)",
     "fr": "Obtenir des extensions de subventions pour les programmes individuels et de ménage (Programme d'aide supplémentaire de l'État)",
     "es": "Obtenga una extensión del subsidio del programa para individuos y familias (Programa Estatal de Subsidio Suplementario)",
@@ -707,7 +653,6 @@
   },
   "plan_visit_fema_grants_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "California Department of Social Services (CDSS)",
     "fr": "Département des services sociaux de Californie (CDSS)",
     "es": "Departamento de Servicios Sociales de California (California Department of Social Services, CDSS)",
@@ -720,7 +665,6 @@
   },
   "plan_visit_documents_section": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Replace your personal documents",
     "fr": "Remplacer vos documents personnels",
     "es": "Remplace sus documentos personales",
@@ -733,7 +677,6 @@
   },
   "plan_visit_documents_vital": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Replace your birth, death, and marriage certificates",
     "fr": "Remplacer vos certificats de naissance, de décès et de mariage",
     "es": "Reemplace sus certificados de nacimiento, muerte y matrimonio",
@@ -746,7 +689,6 @@
   },
   "plan_visit_documents_vital_fees": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "(Fees are waived)",
     "fr": "(Les frais sont remboursés)",
     "es": "(no se aplican tarifas)",
@@ -759,7 +701,6 @@
   },
   "plan_visit_documents_vital_agency_1": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "California Department of Public Health (CDPH)",
     "fr": "Département de la santé publique de Californie (CDPH)",
     "es": "Departamento de Salud Pública de California (CDPH)",
@@ -772,7 +713,6 @@
   },
   "plan_visit_documents_vital_agency_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County Registrar Recorder/County Clerk (RR/CC)",
     "fr": "Département du recenseur enregistrateur/clerc de comté de Los Angeles (RR/CC)",
     "es": "Registrador o secretario (Registrar Recorder/County Clerk, RR/CC) del condado de Los Ángeles",
@@ -785,7 +725,6 @@
   },
   "plan_visit_documents_id": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Replace your identity and car documents",
     "fr": "Remplacer vos documents d'identité et de voiture",
     "es": "Reemplace sus documentos identidad y registro de automóvil",
@@ -798,7 +737,6 @@
   },
   "plan_visit_documents_id_car": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Car registration and titles",
     "fr": "Enregistrement et titres de voiture",
     "es": "registro y títulos del automóvil",
@@ -811,7 +749,6 @@
   },
   "plan_visit_documents_id_license": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Driver’s licenses and ID cards",
     "fr": "Permis de conduire et cartes d'identité",
     "es": "licencias de conducir y tarjetas de identificación",
@@ -824,7 +761,6 @@
   },
   "plan_visit_documents_id_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Department of Motor Vehicles (DMV)",
     "fr": "Département des véhicules terrestres à moteur (DMV)",
     "es": "Departamento de Vehículos Motorizados (Department of Motor Vehicles, DMV)",
@@ -837,7 +773,6 @@
   },
   "plan_visit_documents_mobile_home": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get or replace manufactured and mobile home (MH-unit) documents",
     "fr": "Obtenir ou remplacer les documents des maisons mobiles et des maisons mobiles (MH-unit)",
     "es": "Obtenga o reemplace los documentos de casas móviles (mobile home, MH) o prefabricadas:",
@@ -850,7 +785,6 @@
   },
   "plan_visit_documents_mobile_home_ownership": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Ownership documents",
     "fr": "Documents de propriété",
     "es": "documentos de propiedad",
@@ -863,7 +797,6 @@
   },
   "plan_visit_documents_mobile_home_salvage": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Salvage certificates and removal from HCD registration",
     "fr": "Certificats de sauvetage et retrait de l'enregistrement HCD",
     "es": "recupere certificados y eliminación del registro del Departamento de Vivienda y Desarrollo Comunitario (Housing and Community Development, HCD)",
@@ -876,7 +809,6 @@
   },
   "plan_visit_documents_mobile_home_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Department of Housing and Community Development (HCD)",
     "fr": "Département de l'habitat et du développement communautaire (HCD)",
     "es": "Departamento de Vivienda y Desarrollo Comunitario (HCD)",
@@ -889,7 +821,6 @@
   },
   "plan_visit_documents_property": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Replace your property records",
     "fr": "Remplacer vos enregistrements de propriété",
     "es": "Reemplazar sus registros de propiedad",
@@ -902,7 +833,6 @@
   },
   "plan_visit_documents_property_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County Registrar Recorder/County Clerk (RR/CC)",
     "fr": "Département du recenseur enregistrateur/clerc de comté de Los Angeles (RR/CC)",
     "es": "Registrador o secretario (RR/CC) del condado de Los Ángeles",
@@ -915,7 +845,6 @@
   },
   "plan_visit_documents_tax": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Replace income tax documents",
     "fr": "Remplacer vos documents de taxes sur le revenu",
     "es": "Reemplazar documentos fiscales",
@@ -928,7 +857,6 @@
   },
   "plan_visit_documents_tax_fees": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "(Fees are waived)",
     "fr": "(Les frais sont remboursés)",
     "es": "(no se aplican tarifas)",
@@ -941,7 +869,6 @@
   },
   "plan_visit_documents_tax_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Franchise Tax Board (FTB)",
     "fr": "Département des taxes sur le revenu (FTB)",
     "es": "Junta de Impuestos de Franquicias (Franchise Tax Board, FTB)",
@@ -954,7 +881,6 @@
   },
   "plan_visit_documents_military": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Replace military service records",
     "fr": "Remplacer vos enregistrements de service militaire",
     "es": "Reemplazar los registros de servicio militar estadounidense",
@@ -967,7 +893,6 @@
   },
   "plan_visit_documents_military_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "California Veterans Affairs (CalVet)",
     "fr": "Département des affaires des vétérans de Californie (CalVet)",
     "es": "Asuntos de Veteranos de California (CalVet)",
@@ -980,7 +905,6 @@
   },
   "plan_visit_insurance_section": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Insurance claims",
     "fr": "Réclamations d'assurance",
     "es": "Reclamos de seguro",
@@ -993,7 +917,6 @@
   },
   "plan_visit_insurance_claims": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get help with insurance claims",
     "fr": "Obtenir de l'aide avec les réclamations d'assurance",
     "es": "Obtener ayuda con reclamos de seguro",
@@ -1006,7 +929,6 @@
   },
   "plan_visit_insurance_claims_delays": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Handling delays",
     "fr": "Gestion des retards",
     "es": "demoras de procesamiento",
@@ -1019,7 +941,6 @@
   },
   "plan_visit_insurance_claims_expenses": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Living expenses",
     "fr": "Dépenses de subsistance",
     "es": "gastos de vida",
@@ -1032,7 +953,6 @@
   },
   "plan_visit_insurance_claims_disputes": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Underinsurance disputes",
     "fr": "Différends sur l'assurance sous-assurée",
     "es": "disputas de cobertura insuficiente",
@@ -1045,7 +965,6 @@
   },
   "plan_visit_insurance_claims_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Department of Insurance (CDI)",
     "fr": "Département de l'assurance (CDI)",
     "es": "Departamento de Seguros (Department of Insurance, CDI)",
@@ -1058,7 +977,6 @@
   },
   "plan_visit_employment_section": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Employment",
     "fr": "Emploi",
     "es": "Empleo",
@@ -1071,7 +989,6 @@
   },
   "plan_visit_employment_benefits": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "If you can’t work due to the fires, apply for benefits",
     "fr": "Si vous ne pouvez pas travailler en raison des incendies, appliquez pour des avantages",
     "es": "Si no puede trabajar debido a los incendios, solicite los beneficios",
@@ -1084,7 +1001,6 @@
   },
   "plan_visit_employment_benefits_unemployment": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "State and federal unemployment benefits",
     "fr": "Avantages de chômage fédéral et étatiques",
     "es": "beneficios por desempleo estatales y federales",
@@ -1097,7 +1013,6 @@
   },
   "plan_visit_employment_benefits_disability": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Disability insurance benefits",
     "fr": "Avantages de l'assurance invalidité",
     "es": "beneficios de seguro por discapacidad",
@@ -1110,7 +1025,6 @@
   },
   "plan_visit_employment_benefits_jobs": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Job opportunities and training",
     "fr": "Opportunités d'emploi et formation",
     "es": "oportunidades de trabajo y capacitación",
@@ -1123,7 +1037,6 @@
   },
   "plan_visit_employment_benefits_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Employment Development Department (EDD)",
     "fr": "Département du développement de l'emploi (EDD)",
     "es": "Departamento de Desarrollo de Empleo (Employment Development Department, EDD)",
@@ -1136,7 +1049,6 @@
   },
   "plan_visit_taxes_section": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Taxes",
     "fr": "Impôts",
     "es": "Impuestos",
@@ -1149,7 +1061,6 @@
   },
   "plan_visit_taxes_help": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get help with taxes",
     "fr": "Obtenir de l'aide avec les taxes",
     "es": "Obtener ayuda con impuestos",
@@ -1162,7 +1073,6 @@
   },
   "plan_visit_taxes_help_relief": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Income tax relief and filing assistance",
     "fr": "Relief fiscal sur le revenu et assistance à la déclaration",
     "es": "asistencia para subsidio de impuestos y asistencia para la presentación de declaraciones",
@@ -1175,7 +1085,6 @@
   },
   "plan_visit_taxes_help_address": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Address updates",
     "fr": "Mise à jour de l'adresse",
     "es": "actualizar una dirección",
@@ -1188,7 +1097,6 @@
   },
   "plan_visit_taxes_help_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Franchise Tax Board (FTB)",
     "fr": "Département des taxes sur le revenu (FTB)",
     "es": "Junta de Impuestos de Franquicias (FTB)",
@@ -1201,7 +1109,6 @@
   },
   "plan_visit_taxes_relief": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get help with tax relief",
     "fr": "Obtenir de l'aide avec le relief fiscal",
     "es": "Obtener asistencia para impuestos",
@@ -1214,7 +1121,6 @@
   },
   "plan_visit_taxes_relief_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County Treasurer and Tax Collector (TTC)",
     "fr": "Trésorier et collecteur de taxes de comté de Los Angeles (TTC)",
     "es": "Tesorero y Recaudador de Impuestos (Treasurer and Tax Collector, TTC) del condado de Los Ángeles",
@@ -1227,7 +1133,6 @@
   },
   "plan_visit_rebuilding_section": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Rebuilding help",
     "fr": "Aide pour la reconstruction",
     "es": "Ayuda para reconstruir",
@@ -1240,7 +1145,6 @@
   },
   "plan_visit_rebuilding_clearing": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get help clearing your property",
     "fr": "Obtenir de l'aide pour nettoyer votre propriété",
     "es": "Obtenga ayuda para limpiar su propiedad",
@@ -1253,7 +1157,6 @@
   },
   "plan_visit_rebuilding_clearing_debris": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Debris removal",
     "fr": "Retrait des débris",
     "es": "remoción de escombros",
@@ -1266,7 +1169,6 @@
   },
   "plan_visit_rebuilding_clearing_mud": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Mud and debris flow",
     "fr": "Boue et écoulement de débris",
     "es": "derrumbe de lodo y basura",
@@ -1279,7 +1181,6 @@
   },
   "plan_visit_rebuilding_clearing_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County Public Works (DPW)",
     "fr": "Service public de Los Angeles (DPW)",
     "es": "Departamento de Obras Públicas (Department of Public Works, DPW) del condado de Los Ángeles",
@@ -1292,7 +1193,6 @@
   },
   "plan_visit_rebuilding_process": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get help starting the rebuilding process",
     "fr": "Obtenir de l'aide pour commencer le processus de reconstruction",
     "es": "Obtenga ayuda para comenzar el proceso de reconstrucción:",
@@ -1305,7 +1205,6 @@
   },
   "plan_visit_rebuilding_process_intake": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Project and case intake",
     "fr": "Intake de projet et de cas",
     "es": "admisión de proyectos y casos",
@@ -1318,7 +1217,6 @@
   },
   "plan_visit_rebuilding_process_zoning": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Zoning",
     "fr": "Zonage",
     "es": "zonificación",
@@ -1331,7 +1229,6 @@
   },
   "plan_visit_rebuilding_process_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County Department of Regional Planning",
     "fr": "Département de planification régionale de comté de Los Angeles",
     "es": "Departamento de Planificación Regional del condado de Los Ángeles",
@@ -1344,7 +1241,6 @@
   },
   "plan_visit_rebuilding_permits": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get help with rebuilding permits",
     "fr": "Obtenir de l'aide avec les permis de reconstruction",
     "es": "Obtener ayuda con autorizaciones de reconstrucción",
@@ -1357,7 +1253,6 @@
   },
   "plan_visit_rebuilding_permits_agency_1": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County Public Works (DPW)",
     "fr": "Service public de Los Angeles (DPW)",
     "es": "Departamento de Obras Públicas (DPW) del condado de Los Ángeles",
@@ -1370,7 +1265,6 @@
   },
   "plan_visit_rebuilding_permits_agency_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County Department of Regional Planning",
     "fr": "Département de planification régionale de comté de Los Angeles",
     "es": "Departamento de Planificación Regional del condado de Los Ángeles",
@@ -1383,7 +1277,6 @@
   },
   "plan_visit_rebuilding_contractors": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get help with contractors",
     "fr": "Obtenir de l'aide avec les entrepreneurs",
     "es": "Obtenga ayuda con contratistas",
@@ -1396,7 +1289,6 @@
   },
   "plan_visit_rebuilding_contractors_license": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Making sure your contractor is licensed",
     "fr": "Assurer que votre entrepreneur est licencié",
     "es": "asegurarse de que su contratista tenga licencia",
@@ -1409,7 +1301,6 @@
   },
   "plan_visit_rebuilding_contractors_hiring": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Finding and hiring a licensed contractor",
     "fr": "Recherche et engagement d'un entrepreneur licencié",
     "es": "encontrar y emplear a un contratista autorizado",
@@ -1422,7 +1313,6 @@
   },
   "plan_visit_rebuilding_contractors_complaint": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Filing a complaint",
     "fr": "Déposer une plainte",
     "es": "presentar una queja",
@@ -1435,7 +1325,6 @@
   },
   "plan_visit_rebuilding_contractors_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Contractors State Licensing Board (CSLB)",
     "fr": "Commission des licences d'entrepreneurs de l'État (CSLB)",
     "es": "Junta Estatal de Contratistas Licenciados (Contractors State Licensing Board, CSLB)",
@@ -1448,7 +1337,6 @@
   },
   "plan_visit_rebuilding_case": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get case management and referrals",
     "fr": "Gestion des cas et références",
     "es": "Obtener referencias y administración de casos",
@@ -1461,7 +1349,6 @@
   },
   "plan_visit_rebuilding_case_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County 211",
     "fr": "211 de comté de Los Angeles",
     "es": "LA County 211",
@@ -1474,7 +1361,6 @@
   },
   "plan_visit_rebuilding_dcmp": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get long-term recovery planning through the Disaster Case Management Program (DCMP)",
     "fr": "Obtenir le plan de récupération à long terme via le programme de gestion des cas de catastrophe (DCMP)",
     "es": "Obtener una planificación de recuperación a largo plazo a través del Programa de Administración de Casos por Catástrofes (Disaster Case Management Program, DCMP)",
@@ -1487,7 +1373,6 @@
   },
   "plan_visit_rebuilding_dcmp_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "California Department of Social Services (CDSS)",
     "fr": "Département des services sociaux de Californie (CDSS)",
     "es": "Departamento de Servicios Sociales de California (California Department of Social Services, CDSS)",
@@ -1500,7 +1385,6 @@
   },
   "plan_visit_rebuilding_property": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get help with property reassessment",
     "fr": "Obtenir de l'aide avec la réévaluation de la propriété",
     "es": "Obtenga ayuda con la revaloración de una propiedad",
@@ -1513,7 +1397,6 @@
   },
   "plan_visit_rebuilding_property_items_applications": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Applications",
     "fr": "Applications",
     "es": "solicitudes",
@@ -1526,7 +1409,6 @@
   },
   "plan_visit_rebuilding_property_items_property_value": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Property value information",
     "fr": "Informations sur la valeur de la propriété",
     "es": "información sobre el valor de una propiedad",
@@ -1539,7 +1421,6 @@
   },
   "plan_visit_rebuilding_property_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County Assessor’s Office",
     "fr": "Office du recenseur de comté de Los Angeles",
     "es": "Oficina del tasador del condado de Los Ángeles",
@@ -1552,7 +1433,6 @@
   },
   "plan_visit_rebuilding_calvet": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get CalVet home loans",
     "fr": "Obtenir des prêts immobiliers CalVet",
     "es": "Obtener préstamos para el hogar CalVet ",
@@ -1565,7 +1445,6 @@
   },
   "plan_visit_rebuilding_calvet_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "California Veterans Affairs (CalVet)",
     "fr": "Département des affaires des vétérans de Californie (CalVet)",
     "es": "Asuntos de Veteranos de California (CalVet)",
@@ -1578,7 +1457,6 @@
   },
   "plan_visit_rebuilding_mobile": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get help with mobile home and manufactured home (MH-unit) rebuilding",
     "fr": "Obtenir de l'aide avec la reconstruction de la maison mobile et de la maison modulable (MH-unit)",
     "es": "Obtenga ayuda con la reconstrucción de una casa móvil (MH) o prefabricada",
@@ -1591,7 +1469,6 @@
   },
   "plan_visit_rebuilding_mobile_items": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Application for mobile home park construction, mobile home park MH-unit installation permits",
     "fr": "Demande d'autorisation de construction de parc de maisons mobiles, installation de permis de maison mobile (MH-unit) dans un parc de maisons mobiles",
     "es": "solicitud para la construcción en un complejo de casas móviles, permiso para instalación de MH",
@@ -1604,7 +1481,6 @@
   },
   "plan_visit_rebuilding_mobile_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "California Department of Housing and Community Development (HCD)",
     "fr": "Département du logement et du développement communautaire de Californie (HCD)",
     "es": "Departamento de Vivienda y Desarrollo Comunitario ( HCD) de California",
@@ -1617,7 +1493,6 @@
   },
   "plan_visit_business_section": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Business help",
     "fr": "Aide pour les entreprises",
     "es": "Ayuda para empresas",
@@ -1630,7 +1505,6 @@
   },
   "plan_visit_business_taxes": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get help with business taxes",
     "fr": "Obtenir de l'aide avec les taxes d'entreprise",
     "es": "Obtener ayuda con impuestos de empresas",
@@ -1643,7 +1517,6 @@
   },
   "plan_visit_business_taxes_items_1": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Sales and use tax",
     "fr": "Taxe de vente et d'utilisation",
     "es": "impuestos sobre ventas y uso",
@@ -1656,7 +1529,6 @@
   },
   "plan_visit_business_taxes_items_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Extensions to file returns",
     "fr": "Extensions pour déposer des retours",
     "es": "extensiones para presentar documentos fiscales",
@@ -1669,7 +1541,6 @@
   },
   "plan_visit_business_taxes_items_3": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Relief from interest and penalties",
     "fr": "Relief des intérêts et des pénalités",
     "es": "asistencia para intereses y multas",
@@ -1682,7 +1553,6 @@
   },
   "plan_visit_business_taxes_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "California Department of Tax and Fee Administration (CDTFA)",
     "fr": "Département de la taxe et des frais de Californie (CDTFA)",
     "es": "Departamento de Impuestos y Administración de Tarifas de California (California Department of Tax and Fee Administration, CDTFA)",
@@ -1695,7 +1565,6 @@
   },
   "plan_visit_business_income": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get business income tax relief and filing extensions",
     "fr": "Relief des impôts sur le revenu d'entreprise et extensions pour déposer des retours",
     "es": "Obtener asistencia con impuestos sobre la renta comercial y extensiones de presentación",
@@ -1708,7 +1577,6 @@
   },
   "plan_visit_business_income_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Franchise Tax Board (FTB)",
     "fr": "Département des taxes sur le revenu (FTB)",
     "es": "Junta de Impuestos de Franquicias (FTB)",
@@ -1721,7 +1589,6 @@
   },
   "plan_visit_business_payroll": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get employer payroll tax extensions",
     "fr": "Extensions pour les taxes de paie de l'employeur",
     "es": "Obtener extensiones de impuesto sobre la nómina de empleador",
@@ -1734,7 +1601,6 @@
   },
   "plan_visit_business_payroll_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Employment Development Department (EDD)",
     "fr": "Département du développement de l'emploi (EDD)",
     "es": "Departamento de Desarrollo de Empleo (EDD)",
@@ -1747,7 +1613,6 @@
   },
   "plan_visit_business_records": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Replace your business records",
     "fr": "Remplacer vos enregistrements commerciaux",
     "es": "Reemplazar sus registros comerciales",
@@ -1760,7 +1625,6 @@
   },
   "plan_visit_business_records_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County Registrar Recorder/County Clerk (RR/CC)",
     "fr": "Registre du comté de Los Angeles/Clerc de comté (RR/CC)",
     "es": "Registrador o secretario (RR/CC) del condado de Los Ángeles",
@@ -1773,7 +1637,6 @@
   },
   "plan_visit_business_help": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Get help for businesses",
     "fr": "Obtenir de l'aide pour les entreprises",
     "es": "Obtenga ayuda para empresas",
@@ -1786,7 +1649,6 @@
   },
   "plan_visit_business_help_items_1": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Small business assistance",
     "fr": "Aide aux entreprises de petite taille",
     "es": "ayuda para pequeñas empresas",
@@ -1799,7 +1661,6 @@
   },
   "plan_visit_business_help_items_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Grants",
     "fr": "Subventions",
     "es": "subsidios",
@@ -1812,7 +1673,6 @@
   },
   "plan_visit_business_help_items_3": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "Worker development programs",
     "fr": "Programmes de développement du travail",
     "es": "programas de desarrollo de trabajadores",
@@ -1825,7 +1685,6 @@
   },
   "plan_visit_business_help_agency": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/plan-your-in-person-visit-shared.html",
     "en": "LA County Department of Economic Opportunity (DEO)",
     "fr": "Département de l'opportunité économique de comté de Los Angeles (DEO)",
     "es": "Departamento de Oportunidad Económica (Department of Economic Opportunity, DEO) del condado de LA",

--- a/src/_data/i18n/i18n-real-time.json
+++ b/src/_data/i18n/i18n-real-time.json
@@ -1,7 +1,6 @@
 {
   "realtime_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "See real-time info",
     "fr": "Voir les informations en temps réel",
     "es": "Vea información en tiempo real",
@@ -14,7 +13,6 @@
   },
   "realtime_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Stay safe and informed. These trusted sources of info can help.",
     "fr": "Restez en sécurité et informé. Ces sources de confiance peuvent vous aider.",
     "es": "Manténgase seguro e informado. Estas fuentes de información confiables pueden ayudar.",
@@ -27,7 +25,6 @@
   },
   "realtime_lead_text": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Stay safe and informed. These trusted sources of info can help.",
     "fr": "Restez en sécurité et informé. Ces sources de confiance peuvent vous aider.",
     "es": "Manténgase seguro e informado. Estas fuentes de información confiables pueden ayudar.",
@@ -40,7 +37,6 @@
   },
   "realtime_on_this_page": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "On this page",
     "fr": "Sur cette page",
     "es": "En esta página",
@@ -54,7 +50,6 @@
   "realtime_real_time_updates_heading": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Alerts",
     "fr": "Alertes",
     "es": "Alertas",
@@ -94,7 +89,6 @@
   },
   "realtime_emergency_alerts_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Get emergency alerts",
     "fr": "Recevoir des alertes d'urgence",
     "es": "Obtener alertas de emergencia",
@@ -107,7 +101,6 @@
   },
   "realtime_listos_california_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "from Listos California",
     "fr": "de Listos California",
     "es": "de Listos California",
@@ -120,7 +113,6 @@
   },
   "realtime_consumer_protections_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "from the Office of the Attorney General",
     "fr": "de l'Office de l'Avocat Général",
     "es": "de la Oficina del Fiscal General",
@@ -133,7 +125,6 @@
   },
   "realtime_power_shutoffs_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Power shutoffs",
     "fr": "Coupure de courant",
     "es": "Cortes de energía",
@@ -146,7 +137,6 @@
   },
   "realtime_power_shutoffs_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "from Southern California Edison",
     "fr": "de Southern California Edison",
     "es": "de Southern California Edison",
@@ -159,7 +149,6 @@
   },
   "realtime_school_closures_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "School and government closures",
     "fr": "Fermetures scolaires et gouvernementales",
     "es": "Cierres escolares y gubernamentales",
@@ -172,7 +161,6 @@
   },
   "realtime_school_closures_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "from LA County 211",
     "fr": "de LA County 211",
     "es": "de LA County 211",
@@ -185,7 +173,6 @@
   },
   "realtime_latest_news_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Latest news",
     "fr": "Dernières nouvelles",
     "es": "Últimas noticias",
@@ -198,7 +185,6 @@
   },
   "realtime_latest_news_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "from California Governor’s Office of Emergency Services (Cal OES)",
     "fr": "de l'Office de l'Assistant Général du Gouverneur de Californie pour les Services d'Urgence (Cal OES)",
     "es": "de la Oficina de Servicios de Emergencia del Gobernador de California (California Governor's Office of Emergency Services, Cal OES)",
@@ -211,7 +197,6 @@
   },
   "realtime_traffic_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Traffic maps and road conditions",
     "fr": "Cartes de circulation et conditions routières",
     "es": "Mapas de tráfico y condiciones viales",
@@ -224,7 +209,6 @@
   },
   "realtime_traffic_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "from CalTrans",
     "fr": "de CalTrans",
     "es": "de CalTrans",
@@ -237,7 +221,6 @@
   },
   "realtime_pch_closures": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Pacfic Coast Highway closures (SR1)",
     "fr": "Fermetures de la Pacific Coast Highway (SR1)",
     "es": "cierres de Pacific Coast Highway (SR1)",
@@ -250,7 +233,6 @@
   },
   "realtime_topanga_closures": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Topanga Canyon Road closures (SR27)",
     "fr": "Fermetures de Topanga Canyon Road (SR27)",
     "es": "cierres de Topanga Canyon Road (SR27)",
@@ -263,7 +245,6 @@
   },
   "realtime_other_closures": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Other road closures",
     "fr": "Fermetures de routes autres",
     "es": "otros cierres viales",
@@ -276,7 +257,6 @@
   },
   "realtime_air_quality_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Air quality",
     "fr": "Qualité de l'air",
     "es": "Calidad del aire",
@@ -289,7 +269,6 @@
   },
   "realtime_air_quality_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "from South Coast Air Quality Monitoring District",
     "fr": "de South Coast Air Quality Monitoring District",
     "es": "del Distrito de Monitoreo de la Calidad del Aire de la Costa Sur",
@@ -302,7 +281,6 @@
   },
   "realtime_water_quality_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Water quality",
     "fr": "Qualité de l'eau",
     "es": "Calidad del agua",
@@ -315,7 +293,6 @@
   },
   "realtime_water_quality_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "from State Water Resources Control Board",
     "fr": "de State Water Resources Control Board",
     "es": "de la Junta Estatal de Control de los Recursos Hídricos",
@@ -328,7 +305,6 @@
   },
   "realtime_evacuations_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Evacuations",
     "fr": "Evacuations",
     "es": "Evacuaciones",
@@ -342,7 +318,6 @@
   "realtime_evacuation_notices_heading": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Get evacuation notices",
     "fr": "Recevoir des avis d'évacuation",
     "es": "Recibir avisos de evacuación",
@@ -355,7 +330,6 @@
   },
   "realtime_evacuation_notices_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "from Ready LA County",
     "fr": "de Ready LA County",
     "es": "de Ready LA County",
@@ -368,7 +342,6 @@
   },
   "realtime_evacuation_tips_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Tips for evacuating safely",
     "fr": "Conseils pour évacuer en toute sécurité",
     "es": "Consejos para evacuar de forma segura",
@@ -381,7 +354,6 @@
   },
   "realtime_evacuation_tips_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "from CAL FIRE",
     "fr": "de CAL FIRE",
     "es": "de CAL FIRE",
@@ -395,7 +367,6 @@
   "realtime_getting_prepared_heading": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "How to prepare",
     "fr": "Comment se préparer",
     "es": "Cómo prepararse",
@@ -408,7 +379,6 @@
   },
   "realtime_prepare_for_emergencies_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Prepare for emergencies",
     "fr": "Préparer pour les urgences",
     "es": "Preparación ante emergencias",
@@ -421,7 +391,6 @@
   },
   "realtime_prepare_for_emergencies_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "from Listos California",
     "fr": "de Listos California",
     "es": "de Listos California",
@@ -434,7 +403,6 @@
   },
   "realtime_be_prepared_california_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Be Prepared California",
     "fr": "Préparation de Californie",
     "es": "Be Prepared California",
@@ -447,7 +415,6 @@
   },
   "realtime_be_prepared_california_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "from California Department of Public Health (CDPH)",
     "fr": "de California Department of Public Health (CDPH)",
     "es": "del Departamento de Salud Pública de California (California Department of Public Health, CDPH)",
@@ -461,7 +428,6 @@
   "realtime_roads_heading": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Roads",
     "fr": "Routes",
     "es": "Carreteras",
@@ -475,7 +441,6 @@
   "realtime_roads_card_title": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Road closures and conditions",
     "fr": "Fermetures et conditions des routes",
     "es": "Cierres y condiciones de carreteras",
@@ -489,7 +454,6 @@
   "realtime_roads_card_department": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "from CalTrans",
     "fr": "de CalTrans",
     "es": "de CalTrans",
@@ -503,7 +467,6 @@
   "realtime_roads_card_list_1": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Pacific Coast Highway closures (SR1)",
     "fr": "Fermetures de l'autoroute Pacific Coast (SR1)",
     "es": "Cierres de la autopista Pacific Coast (SR1)",
@@ -517,7 +480,6 @@
   "realtime_roads_card_list_2": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Topanga Canyon Road closures (SR27)",
     "fr": "Fermetures de la route Topanga Canyon (SR27)",
     "es": "Cierres de la carretera Topanga Canyon (SR27)",
@@ -531,7 +493,6 @@
   "realtime_roads_card_list_3": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Other road closures",
     "fr": "Autres fermetures de routes",
     "es": "Otros cierres de carreteras",
@@ -545,7 +506,6 @@
   "realtime_power_heading": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Power",
     "fr": "Électricité",
     "es": "Electricidad",
@@ -559,7 +519,6 @@
   "realtime_environment_heading": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Environment",
     "fr": "Environnement",
     "es": "Medio ambiente",
@@ -573,7 +532,6 @@
   "realtime_air_quality_card_heading": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Air quality",
     "fr": "Qualité de l'air",
     "es": "Calidad del aire",
@@ -587,7 +545,6 @@
   "realtime_air_quality_card_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "from South Coast Air Quality Monitoring District",
     "fr": "du District de surveillance de la qualité de l'air de la côte sud",
     "es": "del Distrito de Monitoreo de la Calidad del Aire de la Costa Sur",
@@ -601,7 +558,6 @@
   "realtime_water_quality_card_heading": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "Water quality",
     "fr": "Qualité de l'eau",
     "es": "Calidad del agua",
@@ -615,7 +571,6 @@
   "realtime_water_quality_card_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/see-real-time-info-shared.html",
     "en": "from State Water Resources Control Board",
     "fr": "du Conseil de contrôle des ressources en eau de l'État",
     "es": "de la Junta Estatal de Control de Recursos Hídricos",

--- a/src/_data/i18n/i18n-service-finder.json
+++ b/src/_data/i18n/i18n-service-finder.json
@@ -2,7 +2,6 @@
   "sf_21_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Prescription medicine help",
     "es": "Ayuda con medicamentos recetados",
     "fr": "Aide pour les médicaments sur ordonnance",
@@ -16,7 +15,6 @@
   "sf_21_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "U.S. Department of Health and Human Services",
     "es": "Departamento de Salud y Servicios Humanos de EE. UU.",
     "fr": "Département américain de la Santé et des Services sociaux",
@@ -30,7 +28,6 @@
   "sf_21_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Get the prescriptions you need through the Emergency Prescription Assistance Program.",
     "es": "Obtenga los medicamentos recetados que necesita a través del Programa de Asistencia para Medicamentos Recetados de Emergencia.",
     "fr": "Obtenez les médicaments dont vous avez besoin grâce au Programme d'assistance pour les médicaments sur ordonnance d'urgence.",
@@ -44,7 +41,6 @@
   "sf_22_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Temporary housing",
     "es": "Vivienda temporal",
     "fr": "Logement temporaire",
@@ -58,7 +54,6 @@
   "sf_22_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Federal Emergency Management Agency",
     "es": "Agencia Federal para el Manejo de Emergencias",
     "fr": "Agence fédérale de gestion des urgences",
@@ -72,7 +67,6 @@
   "sf_22_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "The deadline to apply for FEMA housing assistance was March 31, 2025. You can sign in to DisasterAssistance.gov to check the status of your application. FEMA housing assistance can include rental assistance and hotel or other short-term lodging reimbursement.",
     "es": "La fecha límite para solicitar asistencia de vivienda de FEMA fue el 31 de marzo de 2025. Puede iniciar sesión en DisasterAssistance.gov para verificar el estado de su solicitud. La asistencia de vivienda de FEMA puede incluir asistencia para el alquiler y reembolso de hotel u otro alojamiento a corto plazo.",
     "fr": "La date limite pour demander l'aide au logement de la FEMA était le 31 mars 2025. Vous pouvez vous connecter à DisasterAssistance.gov pour vérifier l'état de votre demande. L'aide au logement de la FEMA peut inclure une aide au loyer et le remboursement de l'hôtel ou d'autres hébergements à court terme.",
@@ -86,7 +80,6 @@
   "sf_23_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "FEMA disaster assistance",
     "es": "Asistencia por desastre de FEMA",
     "fr": "Aide aux sinistrés de la FEMA",
@@ -100,7 +93,6 @@
   "sf_23_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Federal Emergency Management Agency",
     "es": "Agencia Federal para el Manejo de Emergencias",
     "fr": "Agence fédérale de gestion des urgences",
@@ -114,7 +106,6 @@
   "sf_23_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "The deadline to apply for FEMA disaster assistance was March 31, 2025. You can sign in to DisasterAssistance.gov to check the status of your application. FEMA can help with losses not covered by insurance — including temporary housing, repairs, and rebuilding.",
     "es": "La fecha límite para solicitar asistencia por desastre de FEMA fue el 31 de marzo de 2025. Puede iniciar sesión en DisasterAssistance.gov para verificar el estado de su solicitud. FEMA puede ayudar con pérdidas no cubiertas por el seguro, incluyendo vivienda temporal, reparaciones y reconstrucción.",
     "fr": "La date limite pour demander l'aide aux sinistrés de la FEMA était le 31 mars 2025. Vous pouvez vous connecter à DisasterAssistance.gov pour vérifier l'état de votre demande. La FEMA peut aider avec les pertes non couvertes par l'assurance — y compris le logement temporaire, les réparations et la reconstruction.",
@@ -128,7 +119,6 @@
   "sf_25_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Disaster loans for businesses",
     "es": "Préstamos por desastre para negocios",
     "fr": "Prêts aux entreprises en cas de catastrophe",
@@ -142,7 +132,6 @@
   "sf_25_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "U.S. Small Business Administration",
     "es": "Administración de Pequeños Negocios de EE. UU.",
     "fr": "Administration des petites entreprises des États-Unis",
@@ -156,7 +145,6 @@
   "sf_25_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "The deadline to apply for loans to repair physical damage to your business was March 31, 2025. You can still apply by October 25, 2025, for a loan to cover economic losses.",
     "es": "La fecha límite para solicitar préstamos para reparar daños físicos a su negocio fue el 31 de marzo de 2025. Todavía puede solicitar hasta el 25 de octubre de 2025 un préstamo para cubrir pérdidas económicas.",
     "fr": "La date limite pour demander des prêts pour réparer les dommages physiques à votre entreprise était le 31 mars 2025. Vous pouvez encore faire une demande jusqu'au 25 octobre 2025 pour un prêt couvrant les pertes économiques.",
@@ -170,7 +158,6 @@
   "sf_26_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Business use tax or fee extension and relief",
     "es": "Extensión y alivio del impuesto de uso o tarifa comercial",
     "fr": "Prolongation et allègement de la taxe d'utilisation ou des frais commerciaux",
@@ -184,7 +171,6 @@
   "sf_26_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Tax and Fee Administration",
     "es": "Departamento de Administración de Impuestos y Tarifas de California",
     "fr": "Département de l'administration des impôts et des frais de Californie",
@@ -198,7 +184,6 @@
   "sf_26_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Get relief from penalties, collection costs, and interest. You can also get up to a 3-month filing extension on your tax returns.",
     "es": "Obtenga alivio de multas, costos de cobro e intereses. También puede obtener una extensión de hasta 3 meses para presentar sus declaraciones de impuestos.",
     "fr": "Obtenez un allègement des pénalités, des frais de recouvrement et des intérêts. Vous pouvez également obtenir une prolongation de dépôt allant jusqu'à 3 mois pour vos déclarations fiscales.",
@@ -212,7 +197,6 @@
   "sf_27_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Business income tax extension",
     "es": "Extensión del impuesto sobre la renta comercial",
     "fr": "Prolongation de l'impôt sur le revenu des entreprises",
@@ -226,7 +210,6 @@
   "sf_27_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Franchise Tax Board",
     "es": "Junta de Impuestos sobre Franquicias de California",
     "fr": "Conseil des impôts sur les franchises de Californie",
@@ -240,7 +223,6 @@
   "sf_27_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Learn about the extended deadline to file and pay business income tax in Los Angeles County. The new deadline is October 15, 2025.",
     "es": "Conozca sobre la fecha límite extendida para presentar y pagar el impuesto sobre la renta comercial en el Condado de Los Ángeles. La nueva fecha límite es el 15 de octubre de 2025.",
     "fr": "Renseignez-vous sur la date limite prolongée pour déposer et payer l'impôt sur le revenu des entreprises dans le comté de Los Angeles. La nouvelle date limite est le 15 octobre 2025.",
@@ -254,7 +236,6 @@
   "sf_28_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Employer payroll tax and reporting extension",
     "es": "Extensión de impuestos sobre la nómina y reportes del empleador",
     "fr": "Prolongation des impôts sur les salaires et des déclarations de l'employeur",
@@ -268,7 +249,6 @@
   "sf_28_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Employment Development Department",
     "es": "Departamento del Desarrollo del Empleo de California",
     "fr": "Département du développement de l'emploi de Californie",
@@ -282,7 +262,6 @@
   "sf_28_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Get an extension of up to two months to file state payroll reports and deposit state payroll taxes, without penalty or interest. ",
     "es": "Obtenga una extensión de hasta dos meses para presentar informes de nómina estatal y depositar impuestos de nómina estatal, sin multas ni intereses.",
     "fr": "Obtenez une prolongation allant jusqu'à deux mois pour déposer les rapports de paie de l'État et déposer les impôts sur les salaires de l'État, sans pénalité ni intérêt.",
@@ -296,7 +275,6 @@
   "sf_30_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Business recovery resources",
     "es": "Recursos de recuperación empresarial",
     "fr": "Ressources de reprise d'activité",
@@ -310,7 +288,6 @@
   "sf_30_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Office of the Small Business Advocate",
     "es": "Oficina del Defensor de Pequeños Negocios de California",
     "fr": "Bureau californien de défense des petites entreprises",
@@ -324,7 +301,6 @@
   "sf_30_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Find resources and support for businesses and workers impacted by the wildfires. This includes financial help, recovery programs, and workforce support.",
     "es": "Encuentre recursos y apoyo para negocios y trabajadores afectados por los incendios forestales. Esto incluye ayuda financiera, programas de recuperación y apoyo laboral.",
     "fr": "Trouvez des ressources et du soutien pour les entreprises et les travailleurs touchés par les feux de forêt. Cela comprend l'aide financière, les programmes de reprise et le soutien à la main-d'œuvre.",
@@ -338,7 +314,6 @@
   "sf_31_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Unemployment benefits",
     "es": "Beneficios de desempleo",
     "fr": "Prestations de chômage",
@@ -352,7 +327,6 @@
   "sf_31_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Employment Development Department",
     "es": "Departamento del Desarrollo del Empleo de California",
     "fr": "Département du développement de l'emploi de Californie",
@@ -366,7 +340,6 @@
   "sf_31_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "If you lost your job, apply for unemployment benefits.",
     "es": "Si perdió su trabajo, solicite beneficios de desempleo.",
     "fr": "Si vous avez perdu votre emploi, demandez des prestations de chômage.",
@@ -380,7 +353,6 @@
   "sf_32_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Disability benefits",
     "es": "Beneficios por discapacidad",
     "fr": "Prestations d'invalidité",
@@ -394,7 +366,6 @@
   "sf_32_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Employment Development Department",
     "es": "Departamento del Desarrollo del Empleo de California",
     "fr": "Département du développement de l'emploi de Californie",
@@ -408,7 +379,6 @@
   "sf_32_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "If you are sick or injured from the fires, apply for disability benefits.",
     "es": "Si está enfermo o lesionado por los incendios, solicite beneficios por discapacidad.",
     "fr": "Si vous êtes malade ou blessé à cause des incendies, demandez des prestations d'invalidité.",
@@ -422,7 +392,6 @@
   "sf_33_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Paid Family Leave",
     "es": "Permiso Familiar Pagado",
     "fr": "Congé familial payé",
@@ -436,7 +405,6 @@
   "sf_33_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Employment Development Department",
     "es": "Departamento del Desarrollo del Empleo de California",
     "fr": "Département du développement de l'emploi de Californie",
@@ -450,7 +418,6 @@
   "sf_33_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "If you need time off work to care for your family, apply for Paid Family Leave.",
     "es": "Si necesita tiempo libre del trabajo para cuidar a su familia, solicite el Permiso Familiar Pagado.",
     "fr": "Si vous avez besoin de temps libre pour vous occuper de votre famille, demandez un congé familial payé.",
@@ -464,7 +431,6 @@
   "sf_34_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Job search resources",
     "es": "Recursos de búsqueda de empleo",
     "fr": "Ressources de recherche d'emploi",
@@ -478,7 +444,6 @@
   "sf_34_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Employment Development Department",
     "es": "Departamento del Desarrollo del Empleo de California",
     "fr": "Département du développement de l'emploi de Californie",
@@ -492,7 +457,6 @@
   "sf_34_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Find job search tools like CalJOBS and other resources to help you find employment.",
     "es": "Encuentre herramientas de búsqueda de empleo como CalJOBS y otros recursos para ayudarlo a encontrar empleo.",
     "fr": "Trouvez des outils de recherche d'emploi comme CalJOBS et d'autres ressources pour vous aider à trouver un emploi.",
@@ -506,7 +470,6 @@
   "sf_35_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Job training",
     "es": "Capacitación laboral",
     "fr": "Formation professionnelle",
@@ -520,7 +483,6 @@
   "sf_35_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Employment Development Department",
     "es": "Departamento del Desarrollo del Empleo de California",
     "fr": "Département du développement de l'emploi de Californie",
@@ -534,7 +496,6 @@
   "sf_35_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "General support, referrals, and training to find a new job in California.",
     "es": "Apoyo general, referencias y capacitación para encontrar un nuevo trabajo en California.",
     "fr": "Soutien général, références et formation pour trouver un nouvel emploi en Californie.",
@@ -548,7 +509,6 @@
   "sf_36_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "CalJOBS job search system",
     "es": "Sistema de búsqueda de empleo CalJOBS",
     "fr": "Système de recherche d'emploi CalJOBS",
@@ -562,7 +522,6 @@
   "sf_36_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Employment Development Department",
     "es": "Departamento del Desarrollo del Empleo de California",
     "fr": "Département du développement de l'emploi de Californie",
@@ -576,7 +535,6 @@
   "sf_36_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Apply for a new job on CalJOBS, California’s online job exchange system.",
     "es": "Solicite un nuevo trabajo en CalJOBS, el sistema de intercambio de empleos en línea de California.",
     "fr": "Postulez à un nouvel emploi sur CalJOBS, le système d'échange d'emplois en ligne de Californie.",
@@ -590,7 +548,6 @@
   "sf_37_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "WIC food benefits for women and children",
     "es": "Beneficios de alimentos WIC para mujeres y niños",
     "fr": "Prestations alimentaires WIC pour les femmes et les enfants",
@@ -604,7 +561,6 @@
   "sf_37_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Public Health",
     "es": "Departamento de Salud Pública de California",
     "fr": "Département de la santé publique de Californie",
@@ -618,7 +574,6 @@
   "sf_37_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Get monthly benefits from the California Women, Infants and Children (WIC) program. Use these benefits to buy food for yourself and your children. You can also get nutrition and breastfeeding support.",
     "es": "Obtenga beneficios mensuales del programa de Mujeres, Bebés y Niños (WIC) de California. Use estos beneficios para comprar alimentos para usted y sus hijos. También puede obtener apoyo nutricional y para la lactancia.",
     "fr": "Obtenez des prestations mensuelles du programme californien pour les femmes, les nourrissons et les enfants (WIC). Utilisez ces prestations pour acheter de la nourriture pour vous et vos enfants. Vous pouvez également obtenir un soutien en matière de nutrition et d'allaitement.",
@@ -632,7 +587,6 @@
   "sf_38_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "CalFresh food benefits",
     "es": "Beneficios de alimentos de CalFresh",
     "fr": "Prestations alimentaires CalFresh",
@@ -646,7 +600,6 @@
   "sf_38_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Social Services",
     "es": "Departamento de Servicios Sociales de California",
     "fr": "Département des services sociaux de Californie",
@@ -660,7 +613,6 @@
   "sf_38_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "CalFresh can help your family get access to healthy food. You can use monthly CalFresh benefits at most grocery stores and even farmers markets.",
     "es": "CalFresh puede ayudar a su familia a tener acceso a alimentos saludables. Puede usar los beneficios mensuales de CalFresh en la mayoría de las tiendas de comestibles e incluso en los mercados de agricultores.",
     "fr": "CalFresh peut aider votre famille à avoir accès à des aliments sains. Vous pouvez utiliser les prestations mensuelles CalFresh dans la plupart des épiceries et même dans les marchés fermiers.",
@@ -674,7 +626,6 @@
   "sf_39_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Food banks and food pantries",
     "es": "Bancos de alimentos y despensas de alimentos",
     "fr": "Banques alimentaires et garde-manger",
@@ -688,7 +639,6 @@
   "sf_39_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Social Services",
     "es": "Departamento de Servicios Sociales de California",
     "fr": "Département des services sociaux de Californie",
@@ -702,7 +652,6 @@
   "sf_39_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Find locations near you where you can get free food and groceries.",
     "es": "Encuentre ubicaciones cerca de usted donde pueda obtener alimentos y comestibles gratis.",
     "fr": "Trouvez des endroits près de chez vous où vous pouvez obtenir de la nourriture et des produits d'épicerie gratuits.",
@@ -717,7 +666,6 @@
   "sf_41_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Mental health resources",
     "es": "Recursos de salud mental",
     "fr": "Ressources en santé mentale",
@@ -731,7 +679,6 @@
   "sf_41_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Public Health",
     "es": "Departamento de Salud Pública de California",
     "fr": "Département de la santé publique de Californie",
@@ -745,7 +692,6 @@
   "sf_41_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Find resources and tips to take care of your mental health after a wildfire.",
     "es": "Encuentre recursos y consejos para cuidar su salud mental después de un incendio forestal.",
     "fr": "Trouvez des ressources et des conseils pour prendre soin de votre santé mentale après un incendie de forêt.",
@@ -760,7 +706,6 @@
   "sf_43_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Mortgage relief",
     "es": "Alivio hipotecario",
     "fr": "Allègement hypothécaire",
@@ -774,7 +719,6 @@
   "sf_43_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Financial Protection & Innovation",
     "es": "Departamento de Protección Financiera e Innovación de California",
     "fr": "Département de la protection financière et de l'innovation de Californie",
@@ -788,7 +732,6 @@
   "sf_43_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Get mortgage relief for structures damaged or destroyed by the LA fires. Temporarily reduce or pause mortgage payments, waive late fees, and more.",
     "es": "Obtenga alivio hipotecario para estructuras dañadas o destruidas por los incendios de Los Ángeles. Reduzca o pause temporalmente los pagos de la hipoteca, renuncie a los cargos por pagos atrasados y más.",
     "fr": "Obtenez un allègement hypothécaire pour les structures endommagées ou détruites par les incendies de Los Angeles. Réduisez ou suspendez temporairement les paiements hypothécaires, renoncez aux frais de retard, et plus encore.",
@@ -803,7 +746,6 @@
   "sf_44_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "State disaster grants",
     "es": "Subvenciones estatales por desastres",
     "fr": "Subventions d'État pour les catastrophes",
@@ -817,7 +759,6 @@
   "sf_44_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Social Services",
     "es": "Departamento de Servicios Sociales de California",
     "fr": "Département des services sociaux de Californie",
@@ -831,7 +772,6 @@
   "sf_44_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "If you've already received the maximum amount of FEMA disaster assistance, you may be eligible for a grant from California's State Supplemental Grant Program (SSGP). FEMA will automatically apply on your behalf. You don't need to apply directly for these state disaster grants.",
     "es": "Si ya ha recibido la cantidad máxima de asistencia por desastre de FEMA, puede ser elegible para una subvención del Programa de Subvenciones Suplementarias del Estado de California (SSGP). FEMA aplicará automáticamente en su nombre. No necesita solicitar directamente estas subvenciones estatales por desastres.",
     "fr": "Si vous avez déjà reçu le montant maximum de l'aide en cas de catastrophe de la FEMA, vous pouvez être éligible à une subvention du Programme de subventions supplémentaires de l'État de Californie (SSGP). La FEMA appliquera automatiquement en votre nom. Vous n'avez pas besoin de postuler directement pour ces subventions d'État en cas de catastrophe.",
@@ -846,7 +786,6 @@
   "sf_45_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Pet assistance",
     "es": "Asistencia para mascotas",
     "fr": "Assistance pour animaux de compagnie",
@@ -860,7 +799,6 @@
   "sf_45_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Food and Agriculture",
     "es": "Departamento de Alimentos y Agricultura de California",
     "fr": "Département de l'alimentation et de l'agriculture de Californie",
@@ -874,7 +812,6 @@
   "sf_45_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Get help if you lost a pet, had to leave a pet behind, or need shelter for your pet.",
     "es": "Obtenga ayuda si perdió una mascota, tuvo que dejar una mascota atrás o necesita refugio para su mascota.",
     "fr": "Obtenez de l'aide si vous avez perdu un animal de compagnie, si vous avez dû laisser un animal de compagnie derrière vous ou si vous avez besoin d'un abri pour votre animal de compagnie.",
@@ -889,7 +826,6 @@
   "sf_46_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Help for immigrants",
     "es": "Ayuda para inmigrantes",
     "fr": "Aide pour les immigrants",
@@ -903,7 +839,6 @@
   "sf_46_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Social Services",
     "es": "Departamento de Servicios Sociales de California",
     "fr": "Département des services sociaux de Californie",
@@ -917,7 +852,6 @@
   "sf_46_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Find information and guides to disaster assistance for immigrant Californians. Available in Spanish, simplified Chinese, traditional Chinese, and Armenian.",
     "es": "Encuentre información y guías sobre asistencia por desastre para inmigrantes californianos. Disponible en español, chino simplificado, chino tradicional y armenio.",
     "fr": "Trouvez des informations et des guides sur l'aide en cas de catastrophe pour les immigrants californiens. Disponible en espagnol, chinois simplifié, chinois traditionnel et arménien.",
@@ -932,7 +866,6 @@
   "sf_48_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Insurance tips and resources",
     "es": "Consejos y recursos de seguros",
     "fr": "Conseils et ressources en matière d'assurance",
@@ -946,7 +879,6 @@
   "sf_48_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Insurance",
     "es": "Departamento de Seguros de California",
     "fr": "Département des assurances de Californie",
@@ -960,7 +892,6 @@
   "sf_48_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Find tips and resources to help you with insurance claims and issues.",
     "es": "Encuentre consejos y recursos para ayudarlo con reclamos y problemas de seguros.",
     "fr": "Trouvez des conseils et des ressources pour vous aider avec les réclamations et les problèmes d'assurance.",
@@ -975,7 +906,6 @@
   "sf_49_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Insurance protections",
     "es": "Protecciones de seguros",
     "fr": "Protections d'assurance",
@@ -989,7 +919,6 @@
   "sf_49_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Insurance",
     "es": "Departamento de Seguros de California",
     "fr": "Département des assurances de Californie",
@@ -1003,7 +932,6 @@
   "sf_49_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Learn about the state law that prevents insurance companies from canceling or not renewing home insurance policies for one year after a wildfire. And find out if your zip code is protected.",
     "es": "Conozca la ley estatal que impide que las compañías de seguros cancelen o no renueven las pólizas de seguro de hogar durante un año después de un incendio forestal. Y averigüe si su código postal está protegido.",
     "fr": "Renseignez-vous sur la loi de l'État qui empêche les compagnies d'assurance d'annuler ou de ne pas renouveler les polices d'assurance habitation pendant un an après un incendie de forêt. Et découvrez si votre code postal est protégé.",
@@ -1018,7 +946,6 @@
   "sf_50_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Help with insurance claims",
     "es": "Ayuda con reclamos de seguros",
     "fr": "Aide avec les réclamations d'assurance",
@@ -1032,7 +959,6 @@
   "sf_50_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Insurance",
     "es": "Departamento de Seguros de California",
     "fr": "Département des assurances de Californie",
@@ -1046,7 +972,6 @@
   "sf_50_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Get help filing an insurance claim or resolving an issue with a claim you already filed.",
     "es": "Obtenga ayuda para presentar un reclamo de seguro o resolver un problema con un reclamo que ya presentó.",
     "fr": "Obtenez de l'aide pour déposer une réclamation d'assurance ou résoudre un problème avec une réclamation que vous avez déjà déposée.",
@@ -1060,7 +985,6 @@
   "sf_52_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Driver's license or ID cards",
     "es": "Licencia de conducir o tarjetas de identificación",
     "fr": "Permis de conduire ou cartes d'identité",
@@ -1074,7 +998,6 @@
   "sf_52_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Motor Vehicles",
     "es": "Departamento de Vehículos Motorizados de California",
     "fr": "Département des véhicules à moteur de Californie",
@@ -1088,7 +1011,6 @@
   "sf_52_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Replace California driver's licenses or IDs. Fees are waived for licenses or IDs lost in the fires.",
     "es": "Reemplace las licencias de conducir o identificaciones de California. Las tarifas se eximen para las licencias o identificaciones perdidas en los incendios.",
     "fr": "Remplacez les permis de conduire ou les cartes d'identité de Californie. Les frais sont annulés pour les permis ou les cartes d'identité perdus dans les incendies.",
@@ -1103,7 +1025,6 @@
   "sf_53_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Vehicle titles",
     "es": "Títulos de vehículos",
     "fr": "Titres de véhicules",
@@ -1117,7 +1038,6 @@
   "sf_53_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Motor Vehicles",
     "es": "Departamento de Vehículos Motorizados de California",
     "fr": "Département des véhicules à moteur de Californie",
@@ -1131,7 +1051,6 @@
   "sf_53_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Replace titles for vehicles registered in California. Fees are waived for titles lost in the fires.",
     "es": "Reemplace los títulos de los vehículos registrados en California. Las tarifas se eximen para los títulos perdidos en los incendios.",
     "fr": "Remplacez les titres des véhicules immatriculés en Californie. Les frais sont annulés pour les titres perdus dans les incendies.",
@@ -1146,7 +1065,6 @@
   "sf_54_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Manufactured and mobile home documents",
     "es": "Documentos de casas prefabricadas y móviles",
     "fr": "Documents de maisons préfabriquées et mobiles",
@@ -1160,7 +1078,6 @@
   "sf_54_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Housing and Community Development",
     "es": "Departamento de Vivienda y Desarrollo Comunitario de California",
     "fr": "Département du logement et du développement communautaire de Californie",
@@ -1174,7 +1091,6 @@
   "sf_54_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Replace manufactured and mobile home registration and titling documents. Fees may be waived for documents lost in the fires.",
     "es": "Reemplace los documentos de registro y titulación de casas prefabricadas y móviles. Las tarifas pueden ser eximidas para los documentos perdidos en los incendios.",
     "fr": "Remplacez les documents d'enregistrement et de titrage des maisons préfabriquées et mobiles. Les frais peuvent être annulés pour les documents perdus dans les incendies.",
@@ -1189,7 +1105,6 @@
   "sf_55_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Personal income tax documents and info",
     "es": "Documentos e información de impuestos sobre la renta personal",
     "fr": "Documents et informations sur l'impôt sur le revenu personnel",
@@ -1203,7 +1118,6 @@
   "sf_55_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Franchise Tax Board",
     "es": "Junta de Impuestos de Franquicia de California",
     "fr": "Conseil des impôts de franchise de Californie",
@@ -1217,7 +1131,6 @@
   "sf_55_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Replace personal tax documents. File critical changes of information such as change of address and power of attorney.",
     "es": "Reemplace los documentos fiscales personales. Presente cambios críticos de información, como cambio de dirección y poder notarial.",
     "fr": "Remplacez les documents fiscaux personnels. Déposez des modifications critiques d'informations telles que le changement d'adresse et la procuration.",
@@ -1232,7 +1145,6 @@
   "sf_56_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Military service records",
     "es": "Registros de servicio militar",
     "fr": "Dossiers de service militaire",
@@ -1246,7 +1158,6 @@
   "sf_56_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Veterans Affairs",
     "es": "Departamento de Asuntos de Veteranos de California",
     "fr": "Département des anciens combattants de Californie",
@@ -1260,7 +1171,6 @@
   "sf_56_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Learn how to replace service records (DD 214), awards, and medals.",
     "es": "Aprenda cómo reemplazar los registros de servicio (DD 214), premios y medallas.",
     "fr": "Apprenez à remplacer les dossiers de service (DD 214), les récompenses et les médailles.",
@@ -1275,7 +1185,6 @@
   "sf_58_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Licensed contractor search",
     "es": "Búsqueda de contratistas con licencia",
     "fr": "Recherche d'entrepreneurs agréés",
@@ -1289,7 +1198,6 @@
   "sf_58_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Contractors State Licensing Board",
     "es": "Junta Estatal de Licencias de Contratistas de California",
     "fr": "Conseil d'État des licences des entrepreneurs de Californie",
@@ -1303,7 +1211,6 @@
   "sf_58_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Unlicensed contractors often prey on survivors of disasters. To protect yourself, find a licensed contractor near you.",
     "es": "Los contratistas sin licencia a menudo se aprovechan de los sobrevivientes de desastres. Para protegerse, busque un contratista con licencia cerca de usted.",
     "fr": "Les entrepreneurs sans licence profitent souvent des survivants de catastrophes. Pour vous protéger, trouvez un entrepreneur agréé près de chez vous.",
@@ -1318,7 +1225,6 @@
   "sf_59_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Professional licenses check tool",
     "es": "Herramienta de verificación de licencias profesionales",
     "fr": "Outil de vérification des licences professionnelles",
@@ -1332,7 +1238,6 @@
   "sf_59_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Consumer Affairs",
     "es": "Departamento de Asuntos del Consumidor de California",
     "fr": "Département des affaires des consommateurs de Californie",
@@ -1346,7 +1251,6 @@
   "sf_59_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Verify a professional contractor's license. Each record lists a license status as expired, suspended, or revoked.",
     "es": "Verifique la licencia de un contratista profesional. Cada registro enumera el estado de la licencia como vencida, suspendida o revocada.",
     "fr": "Vérifiez la licence d'un entrepreneur professionnel. Chaque dossier indique si la licence est expirée, suspendue ou révoquée.",
@@ -1360,7 +1264,6 @@
   "sf_60_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Disaster case management",
     "es": "Gestión de casos de desastres",
     "fr": "Gestion de cas de catastrophe",
@@ -1374,7 +1277,6 @@
   "sf_60_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Social Services",
     "es": "Departamento de Servicios Sociales de California",
     "fr": "Département des services sociaux de Californie",
@@ -1388,7 +1290,6 @@
   "sf_60_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Work with a case manager from Catholic Charities of California who can guide you through the recovery process.",
     "es": "Trabaje con un administrador de casos de Caridades Católicas de California que puede guiarlo a través del proceso de recuperación.",
     "fr": "Travaillez avec un gestionnaire de cas des Œuvres caritatives catholiques de Californie qui peut vous guider tout au long du processus de rétablissement.",
@@ -1403,7 +1304,6 @@
   "sf_61_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "CalVet home insurance claims",
     "es": "Reclamos de seguro de hogar de CalVet",
     "fr": "Réclamations d'assurance habitation CalVet",
@@ -1417,7 +1317,6 @@
   "sf_61_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Veterans Affairs",
     "es": "Departamento de Asuntos de Veteranos de California",
     "fr": "Département des anciens combattants de Californie",
@@ -1431,7 +1330,6 @@
   "sf_61_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "If you have CalVet home insurance, learn how to file a claim.",
     "es": "Si tiene seguro de hogar de CalVet, aprenda cómo presentar un reclamo.",
     "fr": "Si vous avez une assurance habitation CalVet, apprenez comment déposer une réclamation.",
@@ -1446,7 +1344,6 @@
   "sf_63_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Help for veterans",
     "es": "Ayuda para veteranos",
     "fr": "Aide aux anciens combattants",
@@ -1460,7 +1357,6 @@
   "sf_63_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Veterans Affairs",
     "es": "Departamento de Asuntos de Veteranos de California",
     "fr": "Département des anciens combattants de Californie",
@@ -1474,7 +1370,6 @@
   "sf_63_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Find CalVet information and resources for veterans and their families affected by the Los Angeles wildfires.",
     "es": "Encuentre información y recursos de CalVet para veteranos y sus familias afectados por los incendios forestales de Los Ángeles.",
     "fr": "Trouvez des informations et des ressources CalVet pour les anciens combattants et leurs familles touchés par les feux de forêt de Los Angeles.",
@@ -1489,7 +1384,6 @@
   "sf_65_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Income tax extension",
     "es": "Extensión del impuesto sobre la renta",
     "fr": "Prolongation de l'impôt sur le revenu",
@@ -1503,7 +1397,6 @@
   "sf_65_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Franchise Tax Board",
     "es": "Junta de Impuestos sobre Franquicias de California",
     "fr": "Conseil des impôts sur les franchises de Californie",
@@ -1517,7 +1410,6 @@
   "sf_65_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Learn about the extended deadline to file and pay income tax in Los Angeles County. The new deadline is October 15, 2025.",
     "es": "Conozca sobre la fecha límite extendida para presentar y pagar impuestos sobre la renta en el Condado de Los Ángeles. La nueva fecha límite es el 15 de octubre de 2025.",
     "fr": "Renseignez-vous sur la prolongation du délai pour déclarer et payer l'impôt sur le revenu dans le comté de Los Angeles. La nouvelle date limite est le 15 octobre 2025.",
@@ -1532,7 +1424,6 @@
   "sf_66_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Property tax extension",
     "es": "Extensión del impuesto a la propiedad",
     "fr": "Prolongation de l'impôt foncier",
@@ -1546,7 +1437,6 @@
   "sf_66_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Governor's Office",
     "es": "Oficina del Gobernador de California",
     "fr": "Bureau du gouverneur de Californie",
@@ -1560,7 +1450,6 @@
   "sf_66_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Learn about the extended deadline to file and pay property taxes. The state property tax deadline is also extended. The new deadline is April 10, 2026. For those impacted by the LA fires, Governor Newsom has suspended penalties and interest on late property tax payments. ",
     "es": "Conozca sobre la fecha límite extendida para presentar y pagar impuestos a la propiedad. La fecha límite del impuesto estatal a la propiedad también se ha extendido. La nueva fecha límite es el 10 de abril de 2026. Para los afectados por los incendios de LA, el Gobernador Newsom ha suspendido las multas e intereses por pagos atrasados de impuestos a la propiedad.",
     "fr": "Renseignez-vous sur la prolongation du délai pour déclarer et payer les impôts fonciers. La date limite de l'impôt foncier de l'État est également prolongée. La nouvelle date limite est le 10 avril 2026. Pour les personnes touchées par les incendies de LA, le gouverneur Newsom a suspendu les pénalités et les intérêts sur les paiements tardifs d'impôts fonciers.",
@@ -1575,7 +1464,6 @@
   "sf_67_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Property tax relief",
     "es": "Alivio del impuesto a la propiedad",
     "fr": "Allègement de l'impôt foncier",
@@ -1589,7 +1477,6 @@
   "sf_67_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California State Board of Equalization",
     "es": "Junta de Igualación del Estado de California",
     "fr": "Conseil d'égalisation de l'État de Californie",
@@ -1603,7 +1490,6 @@
   "sf_67_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Get property tax relief if your home was damaged or destroyed.",
     "es": "Obtenga alivio del impuesto a la propiedad si su casa fue dañada o destruida.",
     "fr": "Obtenez un allègement de l'impôt foncier si votre maison a été endommagée ou détruite.",
@@ -1618,7 +1504,6 @@
   "sf_68_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Accessing your property",
     "es": "Acceso a su propiedad",
     "fr": "Accéder à votre propriété",
@@ -1632,7 +1517,6 @@
   "sf_68_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "State of California",
     "es": "Estado de California",
     "fr": "État de Californie",
@@ -1646,7 +1530,6 @@
   "sf_68_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Here\u2019s what you need to know before you return to your home.",
     "es": "Esto es lo que necesita saber antes de regresar a su casa.",
     "fr": "Voici ce que vous devez savoir avant de retourner chez vous.",
@@ -1661,7 +1544,6 @@
   "sf_69_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Air quality monitoring",
     "es": "Monitoreo de la calidad del aire",
     "fr": "Surveillance de la qualité de l'air",
@@ -1675,7 +1557,6 @@
   "sf_69_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "South Coast Air Quality Monitoring District",
     "es": "Distrito de Monitoreo de la Calidad del Aire de la Costa Sur",
     "fr": "District de surveillance de la qualité de l'air de la côte sud",
@@ -1689,7 +1570,6 @@
   "sf_69_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Check your air quality through the South Coast Air Quality Monitoring District.",
     "es": "Verifique la calidad del aire a través del Distrito de Monitoreo de la Calidad del Aire de la Costa Sur.",
     "fr": "Vérifiez la qualité de l'air via le District de surveillance de la qualité de l'air de la côte sud.",
@@ -1704,7 +1584,6 @@
   "sf_70_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Disabled parking placards",
     "es": "Placas de estacionamiento para discapacitados",
     "fr": "Cartes de stationnement pour personnes handicapées",
@@ -1718,7 +1597,6 @@
   "sf_70_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Motor Vehicles",
     "es": "Departamento de Vehículos Motorizados de California",
     "fr": "Département des véhicules motorisés de Californie",
@@ -1732,7 +1610,6 @@
   "sf_70_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Replace Disabled Person Parking Placard.",
     "es": "Reemplace la placa de estacionamiento para personas discapacitadas.",
     "fr": "Remplacer la carte de stationnement pour personnes handicapées.",
@@ -1747,7 +1624,6 @@
   "sf_71_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "License plates and registration stickers",
     "es": "Placas de matrícula y calcomanías de registro",
     "fr": "Plaques d'immatriculation et vignettes d'enregistrement",
@@ -1761,7 +1637,6 @@
   "sf_71_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Motor Vehicles",
     "es": "Departamento de Vehículos Motorizados de California",
     "fr": "Département des véhicules motorisés de Californie",
@@ -1775,7 +1650,6 @@
   "sf_71_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Replace license plates and registration stickers.",
     "es": "Reemplace las placas de matrícula y las calcomanías de registro.",
     "fr": "Remplacer les plaques d'immatriculation et les vignettes d'enregistrement.",
@@ -1790,7 +1664,6 @@
   "sf_72_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Address changes",
     "es": "Cambios de dirección",
     "fr": "Changements d'adresse",
@@ -1804,7 +1677,6 @@
   "sf_72_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Motor Vehicles",
     "es": "Departamento de Vehículos Motorizados de California",
     "fr": "Département des véhicules motorisés de Californie",
@@ -1818,7 +1690,6 @@
   "sf_72_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "File a change of address.",
     "es": "Presente un cambio de dirección.",
     "fr": "Déposer un changement d'adresse.",
@@ -1833,7 +1704,6 @@
   "sf_73_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Vehicle or driver's records",
     "es": "Registros de vehículos o conductores",
     "fr": "Dossiers de véhicule ou de conducteur",
@@ -1847,7 +1717,6 @@
   "sf_73_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Motor Vehicles",
     "es": "Departamento de Vehículos Motorizados de California",
     "fr": "Département des véhicules motorisés de Californie",
@@ -1861,7 +1730,6 @@
   "sf_73_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Replace vehicle or driver's records.",
     "es": "Reemplace los registros del vehículo o del conductor.",
     "fr": "Remplacer les dossiers du véhicule ou du conducteur.",
@@ -1876,7 +1744,6 @@
   "sf_75_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Consumer protections",
     "es": "Protecciones al consumidor",
     "fr": "Protection des consommateurs",
@@ -1890,7 +1757,6 @@
   "sf_75_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Public Utilities Commission",
     "es": "Comisión de Servicios Públicos de California",
     "fr": "Commission des services publics de Californie",
@@ -1904,7 +1770,6 @@
   "sf_75_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Learn about disaster relief protections to help with your energy, natural gas, water, landline, and mobile phone bills. ",
     "es": "Conozca las protecciones de ayuda por desastre para ayudar con sus facturas de energía, gas natural, agua, teléfono fijo y móvil.",
     "fr": "Renseignez-vous sur les protections d'aide en cas de catastrophe pour vous aider avec vos factures d'énergie, de gaz naturel, d'eau, de téléphone fixe et mobile.",
@@ -1919,7 +1784,6 @@
   "sf_76_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Crisis counseling",
     "es": "Consejería de crisis",
     "fr": "Conseil en situation de crise",
@@ -1933,7 +1797,6 @@
   "sf_76_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Social Services",
     "es": "Departamento de Servicios Sociales de California",
     "fr": "Département des services sociaux de Californie",
@@ -1947,7 +1810,6 @@
   "sf_76_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Contact crisis hotlines to get immediate mental health support. ",
     "es": "Comuníquese con las líneas directas de crisis para obtener apoyo inmediato de salud mental.",
     "fr": "Contactez les lignes d'assistance téléphonique en cas de crise pour obtenir un soutien immédiat en santé mentale.",
@@ -1962,7 +1824,6 @@
   "sf_77_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Replace a birth record",
     "es": "Reemplazo de acta de nacimiento",
     "fr": "Remplacer un acte de naissance",
@@ -1976,7 +1837,6 @@
   "sf_77_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Public Health",
     "es": "Departamento de Salud Pública de California",
     "fr": "Département de la santé publique de Californie",
@@ -1990,7 +1850,6 @@
   "sf_77_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "New online service to get a certified copy of a birth record. This process is free for people affected by the LA fires. Must use a notary.",
     "es": "Nuevo servicio en línea para obtener una copia certificada de un acta de nacimiento. Este proceso es gratuito para las personas afectadas por los incendios de Los Ángeles. Debe usar un notario.",
     "fr": "Nouveau service en ligne pour obtenir une copie certifiée d'un acte de naissance. Ce processus est gratuit pour les personnes touchées par les incendies de LA. Doit utiliser un notaire.",
@@ -2005,7 +1864,6 @@
   "sf_78_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Replace a death record",
     "es": "Reemplazo de acta de defunción",
     "fr": "Remplacer un acte de décès",
@@ -2019,7 +1877,6 @@
   "sf_78_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Public Health",
     "es": "Departamento de Salud Pública de California",
     "fr": "Département de la santé publique de Californie",
@@ -2033,7 +1890,6 @@
   "sf_78_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "New online service to get a certified copy of a death record. This process is free for people affected by the LA fires. Must use a notary.",
     "es": "Nuevo servicio en línea para obtener una copia certificada de un acta de defunción. Este proceso es gratuito para las personas afectadas por los incendios de Los Ángeles. Debe usar un notario.",
     "fr": "Nouveau service en ligne pour obtenir une copie certifiée d'un acte de décès. Ce processus est gratuit pour les personnes touchées par les incendies de LA. Doit utiliser un notaire.",
@@ -2048,7 +1904,6 @@
   "sf_79_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Replace a marriage record",
     "es": "Reemplazo de acta de matrimonio",
     "fr": "Remplacer un acte de mariage",
@@ -2062,7 +1917,6 @@
   "sf_79_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Public Health",
     "es": "Departamento de Salud Pública de California",
     "fr": "Département de la santé publique de Californie",
@@ -2076,7 +1930,6 @@
   "sf_79_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "New online service to get a certified copy of a marriage record. This process is free for people affected by the LA fires. Must use a notary.",
     "es": "Nuevo servicio en línea para obtener una copia certificada de un acta de matrimonio. Este proceso es gratuito para las personas afectadas por los incendios de Los Ángeles. Debe usar un notario.",
     "fr": "Nouveau service en ligne pour obtenir une copie certifiée d'un acte de mariage. Ce processus est gratuit pour les personnes touchées par les incendies de LA. Doit utiliser un notaire.",
@@ -2091,7 +1944,6 @@
   "sf_80_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Birth, death, and marriage records",
     "es": "Actas de nacimiento, defunción y matrimonio",
     "fr": "Actes de naissance, de décès et de mariage",
@@ -2105,7 +1957,6 @@
   "sf_80_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Department of Public Health",
     "es": "Departamento de Salud Pública de California",
     "fr": "Département de la santé publique de Californie",
@@ -2119,7 +1970,6 @@
   "sf_80_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Learn how to get replacements of these vital records. The replacements are free, but you’ll need to go in person to a notary and pay a notary fee. Find forms in English and Spanish.",
     "es": "Aprenda cómo obtener reemplazos de estos registros vitales. Los reemplazos son gratuitos, pero deberá acudir en persona a un notario y pagar una tarifa notarial. Encuentre formularios en inglés y español.",
     "fr": "Apprenez comment obtenir des remplacements de ces documents essentiels. Les remplacements sont gratuits, mais vous devrez vous rendre en personne chez un notaire et payer des frais de notaire. Trouvez des formulaires en anglais et en espagnol.",
@@ -2134,7 +1984,6 @@
   "sf_81_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Mental health resources for youth",
     "es": "Recursos de salud mental para jóvenes",
     "fr": "Ressources en santé mentale pour les jeunes",
@@ -2148,7 +1997,6 @@
   "sf_81_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Health and Human Services Agency",
     "es": "Agencia de Salud y Servicios Humanos de California",
     "fr": "Agence de la santé et des services sociaux de Californie",
@@ -2162,7 +2010,6 @@
   "sf_81_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Find digital mental health programs and support for youth, young adults, and families.",
     "es": "Encuentre programas digitales de salud mental y apoyo para jóvenes, adultos jóvenes y familias.",
     "fr": "Trouvez des programmes de santé mentale numériques et du soutien pour les jeunes, les jeunes adultes et les familles.",
@@ -2177,7 +2024,6 @@
   "sf_84_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Safety information for fire cleanup workers ",
     "es": "Información de seguridad para trabajadores de limpieza después de incendios",
     "fr": "Informations de sécurité pour les travailleurs du nettoyage après incendie",
@@ -2191,7 +2037,6 @@
   "sf_84_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "California Labor & Workforce Development Agency",
     "es": "Agencia de Desarrollo Laboral y de la Fuerza Laboral de California",
     "fr": "Agence de développement du travail et de la main-d'œuvre de Californie",
@@ -2205,7 +2050,6 @@
   "sf_84_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "If you work in fire cleanup or debris removal, learn about safety gear and employee protections.",
     "es": "Si trabaja en la limpieza de incendios o remoción de escombros, infórmese sobre el equipo de seguridad y las protecciones para empleados.",
     "fr": "Si vous travaillez dans le nettoyage des incendies ou l'enlèvement des débris, renseignez-vous sur l'équipement de sécurité et les protections des employés.",
@@ -2220,7 +2064,6 @@
   "sf_85_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Steps to rebuilding",
     "es": "Pasos para la reconstrucción",
     "fr": "Étapes de la reconstruction",
@@ -2234,7 +2077,6 @@
   "sf_85_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "State of California",
     "es": "Estado de California",
     "fr": "État de Californie",
@@ -2248,7 +2090,6 @@
   "sf_85_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "See the major steps to take when rebuilding your home. This includes insurance claims, permits, and more.",
     "es": "Vea los pasos principales para reconstruir su casa. Esto incluye reclamos de seguro, permisos y más.",
     "fr": "Découvrez les principales étapes à suivre pour reconstruire votre maison. Cela comprend les réclamations d'assurance, les permis et plus encore.",
@@ -2263,7 +2104,6 @@
   "sf_86_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Free debris removal",
     "es": "Remoción gratuita de escombros",
     "fr": "Enlèvement gratuit des débris",
@@ -2277,7 +2117,6 @@
   "sf_86_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Los Angeles County",
     "es": "Condado de Los Ángeles",
     "fr": "Comté de Los Angeles",
@@ -2291,7 +2130,6 @@
   "sf_86_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Opt in by April 15, 2025, to get free government debris removal. If you don't opt in, you'll need to pay for a private debris removal contractor instead.",
     "es": "Inscríbase antes del 15 de abril de 2025 para obtener la remoción gratuita de escombros por parte del gobierno. Si no se inscribe, deberá pagar a un contratista privado para la remoción de escombros.",
     "fr": "Inscrivez-vous avant le 15 avril 2025 pour bénéficier de l'enlèvement gratuit des débris par le gouvernement. Si vous ne vous inscrivez pas, vous devrez payer un entrepreneur privé pour l'enlèvement des débris.",
@@ -2306,7 +2144,6 @@
   "sf_88_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Disaster loans for homeowners and renters",
     "es": "Préstamos por desastre para propietarios e inquilinos",
     "fr": "Prêts en cas de catastrophe pour les propriétaires et les locataires",
@@ -2320,7 +2157,6 @@
   "sf_88_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "U.S. Small Business Administration",
     "es": "Administración de Pequeños Negocios de EE. UU.",
     "fr": "Administration des petites entreprises des États-Unis",
@@ -2334,7 +2170,6 @@
   "sf_88_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "The deadline to apply for these loans was March 31, 2025. You can sign in to lending.sba.gov to check the status of your application. You can use these loans to repair your home or replace personal property damaged in the fires.",
     "es": "La fecha límite para solicitar estos préstamos fue el 31 de marzo de 2025. Puede iniciar sesión en lending.sba.gov para verificar el estado de su solicitud. Puede usar estos préstamos para reparar su casa o reemplazar bienes personales dañados en los incendios.",
     "fr": "La date limite pour demander ces prêts était le 31 mars 2025. Vous pouvez vous connecter à lending.sba.gov pour vérifier l'état de votre demande. Vous pouvez utiliser ces prêts pour réparer votre maison ou remplacer des biens personnels endommagés dans les incendies.",
@@ -2349,7 +2184,6 @@
   "sf_89_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Worker safety laws for cleanup and rebuilding",
     "es": "Leyes de seguridad laboral para limpieza y reconstrucción",
     "fr": "Lois sur la sécurité des travailleurs pour le nettoyage et la reconstruction",
@@ -2363,7 +2197,6 @@
   "sf_89_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Department of Industrial Relations",
     "es": "Departamento de Relaciones Industriales",
     "fr": "Département des relations industrielles",
@@ -2377,7 +2210,6 @@
   "sf_89_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "If you own a cleanup, debris removal, or rebuilding business, learn about worker safety laws and regulations. Find out how to protect your employees and keep your workplace safe.",
     "es": "Si posee un negocio de limpieza, remoción de escombros o reconstrucción, infórmese sobre las leyes y regulaciones de seguridad laboral. Descubra cómo proteger a sus empleados y mantener su lugar de trabajo seguro.",
     "fr": "Si vous possédez une entreprise de nettoyage, d'enlèvement de débris ou de reconstruction, renseignez-vous sur les lois et réglementations de sécurité des travailleurs. Découvrez comment protéger vos employés et maintenir votre lieu de travail sécuritaire.",
@@ -2391,7 +2223,6 @@
   "sf_90_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Tree removal",
     "es": "Remoción de árboles",
     "fr": "Enlèvement d'arbres",
@@ -2405,7 +2236,6 @@
   "sf_90_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "U.S. Army Corps of Engineers",
     "es": "Cuerpo de Ingenieros del Ejército de los EE. UU.",
     "fr": "Corps des ingénieurs de l'armée américaine",
@@ -2419,7 +2249,6 @@
   "sf_90_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "During debris removal, the Army Corps will remove trees they decide are hazardous. But you can submit a waiver to ask them not to remove specific trees on your property.",
     "es": "Durante la remoción de escombros, el Cuerpo del Ejército removerá los árboles que consideren peligrosos. Pero puede presentar una exención para solicitar que no remuevan árboles específicos en su propiedad.",
     "fr": "Pendant l'enlèvement des débris, le Corps des ingénieurs enlèvera les arbres qu'ils jugent dangereux. Mais vous pouvez soumettre une dérogation pour leur demander de ne pas enlever certains arbres sur votre propriété.",
@@ -2433,7 +2262,6 @@
   "sf_91_service_name": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Free debris removal for some commercial properties",
     "es": "Remoción de escombros gratuita para algunas propiedades comerciales",
     "fr": "Enlèvement gratuit des débris pour certaines propriétés commerciales",
@@ -2447,7 +2275,6 @@
   "sf_91_entity": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "U.S. Army Corps of Engineers",
     "es": "Cuerpo de Ingenieros del Ejército de los EE. UU.",
     "fr": "Corps des ingénieurs de l'armée américaine",
@@ -2461,7 +2288,6 @@
   "sf_91_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/airTable.json",
     "en": "Opt in by April 15, 2025, to find out if your business qualifies for free government debris removal. ",
     "es": "Inscríbase antes del 15 de abril de 2025 para obtener la remoción gratuita de escombros por parte del gobierno. ",
     "fr": "Inscrivez-vous avant le 15 avril 2025 pour bénéficier de l'enlèvement gratuit des débris par le gouvernement. ",
@@ -2475,7 +2301,6 @@
   "sf_service_title_essential_help": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_types.csv",
     "en": "Essential help for individuals",
     "es": "Ayuda esencial para individuos",
     "fr": "Aide essentielle pour les individus",
@@ -2489,7 +2314,6 @@
   "sf_service_title_start_recovering": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_types.csv",
     "en": "Start recovering for individuals",
     "es": "Comenzar la recuperación para individuos",
     "fr": "Commencer à se rétablir pour les individus",
@@ -2503,7 +2327,6 @@
   "sf_service_title_business_help": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_types.csv",
     "en": "Business help",
     "es": "Ayuda para negocios",
     "fr": "Aide aux entreprises",
@@ -2518,7 +2341,6 @@
   "sf_cat_label_essential_help_housing": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Housing",
     "fr": "Logement",
     "es": "Vivienda",
@@ -2533,7 +2355,6 @@
   "sf_cat_description_essential_help_housing": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Shelters, temporary housing, mortgage relief",
     "fr": "Refuges, logements temporaires, allègement hypothécaire",
     "es": "Refugios, vivienda temporal, alivio hipotecario",
@@ -2548,7 +2369,6 @@
   "sf_cat_description_essential_help_food": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Food or food benefits",
     "fr": "Nourriture ou avantages alimentaires",
     "es": "Alimentos o beneficios alimentarios",
@@ -2563,7 +2383,6 @@
   "sf_cat_label_essential_help_food": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Food",
     "fr": "Nourriture",
     "es": "Alimentos",
@@ -2578,7 +2397,6 @@
   "sf_cat_label_essential_help_pets": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Pets",
     "fr": "Animaux",
     "es": "Mascotas",
@@ -2593,7 +2411,6 @@
   "sf_cat_description_essential_help_pets": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Lost or found a pet, and more",
     "fr": "Animal de compagnie perdu ou trouvé, et plus",
     "es": "Mascota perdida o encontrada, y más",
@@ -2608,7 +2425,6 @@
   "sf_cat_label_essential_help_health": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Health",
     "fr": "Santé",
     "es": "Salud",
@@ -2623,7 +2439,6 @@
   "sf_cat_description_essential_help_health": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Staying healthy, mental health",
     "fr": "Rester en bonne santé, santé mentale",
     "es": "Mantenerse saludable, salud mental",
@@ -2638,7 +2453,6 @@
   "sf_cat_label_essential_help_individual_help": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Individual help",
     "fr": "Aide individuelle",
     "es": "Ayuda individual",
@@ -2653,7 +2467,6 @@
   "sf_cat_description_essential_help_individual_help": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "State and federal (FEMA) programs that help disaster survivors",
     "fr": "Programmes d'aide étatiques et fédéraux (FEMA) pour les survivants de catastrophes",
     "es": "Programas estatales y federales (FEMA) que ayudan a los sobrevivientes de desastres",
@@ -2668,7 +2481,6 @@
   "sf_cat_label_essential_help_personal_documents": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Personal documents",
     "fr": "Documents personnels",
     "es": "Documentos personales",
@@ -2683,7 +2495,6 @@
   "sf_cat_description_essential_help_personal_documents": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Driver's license, birth, death, and marriage records",
     "fr": "Permis de conduire, actes de naissance, de décès et de mariage",
     "es": "Licencia de conducir, registros de nacimiento, defunción y matrimonio",
@@ -2698,7 +2509,6 @@
   "sf_cat_label_start_recovering_returning_home": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Returning home",
     "fr": "Retour à la maison",
     "es": "Regreso a casa",
@@ -2713,7 +2523,6 @@
   "sf_cat_description_start_recovering_returning_home": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Assessments, cleanup, debris removal",
     "fr": "Évaluations, nettoyage, enlèvement des débris",
     "es": "Evaluaciones, limpieza, remoción de escombros",
@@ -2728,7 +2537,6 @@
   "sf_cat_label_start_recovering_insurance": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Insurance",
     "fr": "Assurance",
     "es": "Seguro",
@@ -2743,7 +2551,6 @@
   "sf_cat_description_start_recovering_insurance": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Home insurance and insurance claims",
     "fr": "Assurance habitation et réclamations d'assurance",
     "es": "Seguro de vivienda y reclamos de seguro",
@@ -2758,7 +2565,6 @@
   "sf_cat_label_start_recovering_rebuilding": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Rebuilding",
     "fr": "Reconstruction",
     "es": "Reconstrucción",
@@ -2773,7 +2579,6 @@
   "sf_cat_description_start_recovering_rebuilding": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Find a contractor, verify a professional license",
     "fr": "Trouver un entrepreneur, vérifier une licence professionnelle",
     "es": "Encontrar un contratista, verificar una licencia profesional",
@@ -2788,7 +2593,6 @@
   "sf_cat_label_start_recovering_employment": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Employment",
     "fr": "Emploi",
     "es": "Empleo",
@@ -2803,7 +2607,6 @@
   "sf_cat_description_start_recovering_employment": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Unemployment, disability, find a job",
     "fr": "Chômage, invalidité, trouver un emploi",
     "es": "Desempleo, discapacidad, encontrar trabajo",
@@ -2818,7 +2621,6 @@
   "sf_cat_label_start_recovering_taxes": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Taxes",
     "fr": "Impôts",
     "es": "Impuestos",
@@ -2832,7 +2634,6 @@
   "sf_cat_description_start_recovering_taxes": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Relief for income and property taxes",
     "fr": "Allègement pour les impôts sur le revenu et les taxes foncières",
     "es": "Alivio para impuestos sobre la renta y la propiedad",
@@ -2847,7 +2648,6 @@
   "sf_cat_label_business_help_support": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Support",
     "fr": "Aide financière",
     "es": "Apoyo",
@@ -2862,7 +2662,6 @@
   "sf_cat_description_business_help_support": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Financial help, recovery, disaster relief payments, small businesses",
     "fr": "Aide financière, reprise, paiements de secours en cas de catastrophe, petites entreprises",
     "es": "Ayuda financiera, recuperación, pagos de ayuda por desastre, pequeñas empresas",
@@ -2877,7 +2676,6 @@
   "sf_cat_label_business_help_tax_help_and_relief": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Tax help and relief",
     "fr": "Impôts et aide",
     "es": "Ayuda y alivio fiscal",
@@ -2892,7 +2690,6 @@
   "sf_cat_description_business_help_tax_help_and_relief": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_data/lafires/recovery_services_categories.csv",
     "en": "Income taxes, sales tax, payroll taxes",
     "fr": "Impôts sur le revenu, taxe de vente, taxes sur la paie",
     "es": "Impuestos sobre la renta, impuesto sobre las ventas, impuestos sobre la nómina",
@@ -2905,7 +2702,6 @@
   },
   "sf_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/recovery-services-all-shared.html",
     "en": "Recovery services finder",
     "fr": "Recherche de services de récupération",
     "es": "Buscador de servicios de recuperación",
@@ -2918,7 +2714,6 @@
   },
   "sf_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/recovery-services-all-shared.html",
     "en": "Here is a customized services plan for you. We provides direct links or information on how to get these services.",
     "fr": "Voici un plan de services personnalisé pour vous. Nous fournissons des liens directs ou des informations sur la façon de recevoir ces services.",
     "es": "Este es un plan de servicios personalizado para usted. Le proporciona información directa sobre cómo obtener estos servicios.",
@@ -2931,7 +2726,6 @@
   },
   "sf_h1_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/recovery-services-all-shared.html",
     "en": "Recovery services finder",
     "fr": "Recherche de services de récupération",
     "es": "Buscador de servicios de recuperación",
@@ -2944,7 +2738,6 @@
   },
   "sf_h1_subtitle": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/recovery-services-all-shared.html",
     "en": "Your customized services plans",
     "fr": "Votre plan de services personnalisé",
     "es": "Sus planes de servicio personalizados",
@@ -2957,7 +2750,6 @@
   },
   "sf_back_link": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/recovery-services-all-shared.html",
     "en": "Back to Get help online",
     "fr": "Retour à Obtenir de l'aide en ligne",
     "es": "Volver a Obtenga ayuda en línea",
@@ -2970,7 +2762,6 @@
   },
   "sf_lead_text": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/recovery-services-all-shared.html",
     "en": "Here are the services that meet your needs. We provide direct links or information on how to get these services.",
     "fr": "Voici les services qui répondent à vos besoins. Nous fournissons des liens directs ou des informations sur la façon de recevoir ces services.",
     "es": "Estos son los servicios que cumplen con sus necesidades. Le proporcionamos información directa sobre cómo obtener estos servicios.",
@@ -2983,7 +2774,6 @@
   },
   "sf_print_button": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/recovery-services-all-shared.html",
     "en": "Print your plan",
     "fr": "Imprimer votre plan",
     "es": "Imprima su plan",
@@ -3048,7 +2838,6 @@
   },
   "sf_create_link_text": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/recovery-services-all-shared.html",
     "en": "Create new plan",
     "fr": "Créer un nouveau plan",
     "es": "Crear un nuevo plan",
@@ -3061,7 +2850,6 @@
   },
   "sf_navigator_text": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/recovery-services-all-shared.html",
     "en": "To find local services, check out the <a href=\"https://wildfires.betterangels.la/\">LA Disaster Relief Navigator</a>, a user-friendly community resource hub.",
     "fr": "Pour trouver des services locaux, consultez le <a href=\"https://wildfires.betterangels.la/\">LA Disaster Relief Navigator</a>, un hub de ressources communautaires facile à utiliser.",
     "es": "Para encontrar servicios locales, consulte la <a href=\"https://wildfires.betterangels.la/\">Guía de ayuda en casos de catástrofes de Los Ángeles</a>, un centro de recursos comunitarios fácil de usar.",
@@ -3075,7 +2863,6 @@
   },
   "sf_lead_text_1": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/recovery-services-finder-shared.html",
     "en": "There are a lot of disaster services available from the state and federal government. Use this tool to get a customized list.",
     "fr": "Il existe de nombreux services de catastrophe disponibles provenant de l'État et du gouvernement fédéral. Utilisez cet outil pour obtenir une liste personnalisée.",
     "es": "Hay muchos servicios para desastres disponibles por parte del gobierno estatal y federal. Use esta herramienta para obtener una lista personalizada.",
@@ -3088,7 +2875,6 @@
   },
   "sf_lead_text_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/recovery-services-finder-shared.html",
     "en": "Select all the items you need.",
     "fr": "Sélectionnez tous les éléments dont vous avez besoin.",
     "es": "Seleccione todos los artículos que necesite.",
@@ -3101,7 +2887,6 @@
   },
   "sf_individuals_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/recovery-services-finder-shared.html",
     "en": "Individuals",
     "fr": "Personnes",
     "es": "Individuos",
@@ -3114,7 +2899,6 @@
   },
   "sf_essential_help_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/recovery-services-finder-shared.html",
     "en": "Essential help",
     "fr": "Aide essentielle",
     "es": "Ayuda esencial",
@@ -3127,7 +2911,6 @@
   },
   "sf_start_recovering_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/recovery-services-finder-shared.html",
     "en": "Start recovering",
     "fr": "Commencer à récupérer",
     "es": "Comenzar a recuperarse",
@@ -3140,7 +2923,6 @@
   },
   "sf_business_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/recovery-services-finder-shared.html",
     "en": "Business",
     "fr": "Entreprise",
     "es": "Negocios",
@@ -3153,7 +2935,6 @@
   },
   "sf_submit_button": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/recovery-services-finder-shared.html",
     "en": "Submit",
     "fr": "Soumettre",
     "es": "Enviar",

--- a/src/_data/i18n/i18n-sidenav.json
+++ b/src/_data/i18n/i18n-sidenav.json
@@ -1,7 +1,6 @@
 {
   "sidenav_2025_los_angeles_fires": {
     "status": "avantpage_delivery",
-    "src_file": "src/_includes/dynamic-sidenav.html",
     "en": "2025 Los Angeles fires",
     "es": "Incendios de Los Ángeles en 2025",
     "ko": "2025년 로스앤젤레스 화재",
@@ -13,7 +12,6 @@
   },
   "sidenav_get_help_online": {
     "status": "avantpage_delivery",
-    "src_file": "src/_includes/dynamic-sidenav.html",
     "en": "Get help online",
     "fr": "Obtenir de l'aide en ligne",
     "es": "Obtenga ayuda en línea",
@@ -26,7 +24,6 @@
   },
   "sidenav_recovery_services_finder": {
     "status": "avantpage_delivery",
-    "src_file": "src/_includes/dynamic-sidenav.html",
     "en": "Recovery services finder",
     "fr": "Recherche de services de récupération",
     "es": "Buscador de servicios de recuperación",
@@ -39,7 +36,6 @@
   },
   "sidenav_vital_records": {
     "status": "avantpage_delivery",
-    "src_file": "src/_includes/dynamic-sidenav.html",
     "en": "Vital records",
     "fr": "Certificats de naissance, mariage et décès",
     "es": "Documentos del registro civil",
@@ -52,7 +48,6 @@
   },
   "sidenav_get_help_in_person": {
     "status": "avantpage_delivery",
-    "src_file": "src/_includes/dynamic-sidenav.html",
     "en": "Get help in person",
     "fr": "Obtenir de l'aide en personne",
     "es": "Obtenga ayuda en persona",
@@ -65,7 +60,6 @@
   },
   "sidenav_plan_your_in_person_visit": {
     "status": "avantpage_delivery",
-    "src_file": "src/_includes/dynamic-sidenav.html",
     "en": "Plan your in-person visit",
     "fr": "Planifier votre visite en personne",
     "es": "Planee su visita en persona",
@@ -78,7 +72,6 @@
   },
   "sidenav_see_real_time_info": {
     "status": "avantpage_delivery",
-    "src_file": "src/_includes/dynamic-sidenav.html",
     "en": "See real-time info",
     "fr": "Voir les informations en temps réel",
     "es": "Vea información en tiempo real",
@@ -91,7 +84,6 @@
   },
   "sidenav_start_your_recovery": {
     "status": "avantpage_delivery",
-    "src_file": "src/_includes/dynamic-sidenav.html",
     "en": "Start your recovery",
     "fr": "Commencez votre récupération",
     "es": "Comience la recuperación",
@@ -105,7 +97,6 @@
   "sidenav_accessing_your_property": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "src/_includes/dynamic-sidenav.html",
     "en": "Accessing your property",
     "fr": "Accéder à votre propriété",
     "es": "Acceder a su propiedad",
@@ -118,7 +109,6 @@
   },
   "sidenav_cleanup_and_debris_removal": {
     "status": "avantpage_delivery",
-    "src_file": "src/_includes/dynamic-sidenav.html",
     "en": "Cleanup and debris removal",
     "es": "Limpieza y remoción de escombros",
     "ko": "청소 및 잔해 제거",
@@ -130,7 +120,6 @@
   },
   "sidenav_steps_to_rebuilding": {
     "status": "avantpage_delivery",
-    "src_file": "src/_includes/dynamic-sidenav.html",
     "en": "Steps to rebuilding",
     "es": "Pasos para la reconstrucción",
     "ko": "재건 단계",
@@ -142,7 +131,6 @@
   },
   "sidenav_help_your_business": {
     "status": "avantpage_delivery",
-    "src_file": "src/_includes/dynamic-sidenav.html",
     "en": "Help your business",
     "es": "Ayuda para su negocio",
     "ko": "비즈니스 지원",
@@ -154,7 +142,6 @@
   },
   "sidenav_volunteer": {
     "status": "avantpage_delivery",
-    "src_file": "src/_includes/dynamic-sidenav.html",
     "en": "Volunteer",
     "es": "Ser voluntario",
     "ko": "자원봉사",
@@ -166,7 +153,6 @@
   },
   "sidenav_stay_healthy": {
     "status": "avantpage_delivery",
-    "src_file": "src/_includes/dynamic-sidenav.html",
     "en": "Stay healthy",
     "es": "Mantenerse saludable",
     "ko": "건강 유지",
@@ -178,7 +164,6 @@
   },
   "sidenav_track_las_progress": {
     "status": "avantpage_delivery",
-    "src_file": "src/_includes/dynamic-sidenav.html",
     "en": "Track LA’s progress",
     "es": "Siga el progreso de Los Ángeles",
     "ko": "LA의 진행 상황 추적",

--- a/src/_data/i18n/i18n-start-your-recovery.json
+++ b/src/_data/i18n/i18n-start-your-recovery.json
@@ -1,7 +1,6 @@
 {
   "recovery_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "Start your recovery",
     "fr": "Commencez votre rétablissement",
     "es": "Comience la recuperación",
@@ -15,7 +14,6 @@
   "recovery_description": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "Learn how to get what you need to start recovering.",
     "fr": "Apprenez comment obtenir ce dont vous avez besoin pour commencer à récupérer.",
     "es": "Aprenda cómo obtener lo que necesita para comenzar a recuperar.",
@@ -29,7 +27,6 @@
   "recovery_lead_text": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "Learn how to get what you need to start recovering.",
     "fr": "Apprenez comment obtenir ce dont vous avez besoin pour commencer à récupérer.",
     "es": "Aprenda cómo obtener lo que necesita para comenzar a recuperar.",
@@ -42,7 +39,6 @@
   },
   "recovery_document_note": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "If you need to replace documents like IDs, do that first. See <a href=\"/lafires/get-help-online/#Replacing-your-personal-documents\">Replacing your personal documents</a>.",
     "fr": "Si vous devez remplacer des documents comme des pièces d'identité, faites-le en premier. Consultez <a href=\"/lafires/fr/get-help-online/#Replacing-your-personal-documents\">Remplacement de vos documents personnels</a>.",
     "es": "Si necesita reemplazar documentos como tarjetas de identificación, haga eso primero. Consulte <a href=\"/lafires/es/get-help-online/#Replacing-your-personal-documents\">Remplazar sus documentos personales</a>",
@@ -56,7 +52,6 @@
   "recovery_returning_home_heading": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "Accessing your property",
     "fr": "Accéder à votre propriété",
     "es": "Acceder a su propiedad",
@@ -83,7 +78,6 @@
   "recovery_return_home_button_text": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "How to access your property safely",
     "fr": "Comment accéder à votre propriété en toute sécurité",
     "es": "Cómo acceder a su propiedad de manera segura",
@@ -96,7 +90,6 @@
   },
   "recovery_insurance_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "Filing insurance claims",
     "fr": "Dépôt des réclamations d'assurance",
     "es": "Presentar reclamos de seguro",
@@ -109,7 +102,6 @@
   },
   "recovery_insurance_prompt": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "If you have insurance, file a claim as soon as possible.",
     "fr": "Si vous avez une assurance, déposez une réclamation dès que possible.",
     "es": "Si tiene seguro, presente un reclamo lo antes posible.",
@@ -122,7 +114,6 @@
   },
   "recovery_california_protects_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "California protects you from losing your home insurance",
     "fr": "La Californie vous protège contre la perte de votre assurance habitation",
     "es": "California lo protege de perder el seguro de su hogar",
@@ -135,7 +126,6 @@
   },
   "recovery_california_protects_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "State law protects residents. It prevents insurance companies from canceling or not renewing home insurance polices for one year in areas near a wildfire. This 1-year moratorium applies to all residents in the affected area, including total and no loss.",
     "fr": "La loi de l'État protège les résidents. Elle empêche les compagnies d'assurance d'annuler ou de ne pas renouveler les polices d'assurance habitation pendant un an dans les zones proches d'un incendie de forêt. Ce moratoire d'un an s'applique à tous les résidents de la zone touchée, y compris en cas de perte totale ou d'absence de perte.",
     "es": "La ley estatal protege a los residentes. Esto impide que las compañías de seguros cancelen o no renueven pólizas de seguro de hogares durante un año en áreas cercanas a un área que se incendió. Esta moratoria de un año se aplica a todos los residentes en el área afectada, incluida la pérdida total y nula.",
@@ -148,7 +138,6 @@
   },
   "recovery_get_help_claim_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "Get help with your claim",
     "fr": "Obtenez de l'aide pour votre réclamation",
     "es": "Obtenga ayuda con su reclamo",
@@ -161,7 +150,6 @@
   },
   "recovery_get_help_claim_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "California Department of Insurance (CDI) gives help in many languages.",
     "fr": "Le Département des assurances de Californie (CDI) offre de l'aide en plusieurs langues.",
     "es": "El Departamento de Seguros de California (California Department of Insurance, CDI) brinda ayuda en muchos idiomas.",
@@ -174,7 +162,6 @@
   },
   "recovery_get_help_claim_items_1": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "Resources to help recent wildfire victims",
     "fr": "Ressources pour aider les victimes récentes des feux de forêt",
     "es": "Recursos para ayudar a las víctimas recientes de incendios forestales",
@@ -187,7 +174,6 @@
   },
   "recovery_get_help_claim_items_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "Top ten tips for wildfire claims",
     "fr": "Les dix meilleurs conseils pour les réclamations liées aux feux de forêt",
     "es": "Diez consejos principales para reclamaciones por incendios forestales",
@@ -200,7 +186,6 @@
   },
   "recovery_get_help_claim_items_3": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "Working with contractors",
     "fr": "Travailler avec des entrepreneurs",
     "es": "Trabajar con contratistas",
@@ -213,7 +198,6 @@
   },
   "recovery_get_help_claim_items_4": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "Help with CalVet claims",
     "fr": "Aide pour les réclamations CalVet",
     "es": "Ayuda con las reclamaciones de Asuntos de Veteranos de California (California Veterans Affairs, CalVet)",
@@ -227,7 +211,6 @@
   "recovery_get_help_claim_items_5": {
     "status": "ap_review",
     "comment": "machine translated, original text modified",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "On the phone: Call <a href=\"tel:1-800-927-4357\">1-800-927-4357</a> (HELP) or TTY: <a href=\"tel:1-800-482-4833\">1-800-482-4833</a> for assistance",
     "fr": "Par téléphone: Appeler <a href=\"tel:1-800-927-4357\">1-800-927-4357</a> (HELP) ou TTY: <a href=\"tel:1-800-482-4833\">1-800-482-4833</a> pour obtenir de l'aide",
     "es": "Por teléfono: Llame al <a href=\"tel:1-800-927-4357\">1-800-927-4357</a> (AYUDA) o TTY: <a href=\"tel:1-800-482-4833\">1-800-482-4833</a> para obtener ayuda",
@@ -240,7 +223,6 @@
   },
   "recovery_get_help_claim_items_6": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "In-person insurance workshops will be offered on the weekend of January 25",
     "fr": "Des ateliers d'assurance en personne seront proposés le week-end du 25 janvier",
     "es": "Los talleres de seguro en persona se ofrecerán el fin de semana del 25 de enero.",
@@ -253,7 +235,6 @@
   },
   "recovery_rebuilding_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "Rebuilding",
     "fr": "Reconstruction",
     "es": "Reconstruir",
@@ -266,7 +247,6 @@
   },
   "recovery_rebuilding_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "See the major steps to take when rebuilding your home.",
     "fr": "Découvrez les principales étapes à suivre pour reconstruire votre maison.",
     "es": "Consulte los pasos principales a seguir cuando reconstruya su hogar.",
@@ -279,7 +259,6 @@
   },
   "recovery_steps_to_rebuilding_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "See the major steps to take when rebuilding your home.",
     "fr": "Découvrez les principales étapes à suivre pour reconstruire votre maison.",
     "es": "Consulte los pasos principales a seguir cuando reconstruya su hogar.",
@@ -292,7 +271,6 @@
   },
   "recovery_steps_to_rebuilding_button_text": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "Steps to rebuilding",
     "fr": "Étapes de la reconstruction",
     "es": "Pasos para la reconstrucción",
@@ -305,7 +283,6 @@
   },
   "recovery_employment_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "Employment",
     "fr": "Emploi",
     "es": "Empleo",
@@ -318,7 +295,6 @@
   },
   "recovery_cant_work_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "If you can’t work",
     "fr": "Si vous ne pouvez pas travailler",
     "es": "Si no puede trabajar",
@@ -331,7 +307,6 @@
   },
   "recovery_cant_work_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "You may not be able to work for many reasons. Here’s how to receive wage replacement during this time.",
     "fr": "Vous pourriez ne pas être en mesure de travailler pour plusieurs raisons. Voici comment recevoir un remplacement de salaire pendant cette période.",
     "es": "Es posible que no pueda trabajar por muchas razones. Esto es lo que debe hacer para recibir un salario de reemplazo durante este tiempo.",
@@ -344,7 +319,6 @@
   },
   "recovery_cant_work_items_1": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "If you lost your job due to the fire, apply for <a href=\"https://edd.ca.gov/en/unemployment/disaster_unemployment_assistance\">unemployment</a>",
     "fr": "Si vous avez perdu votre emploi à cause de l'incendie, faites une demande d'<a href=\"https://edd.ca.gov/en/unemployment/disaster_unemployment_assistance\">allocation chômage</a>",
     "es": "Si perdió su trabajo a causa de los incendios, solicite los beneficios por <a href=\"https://edd.ca.gov/en/unemployment/disaster_unemployment_assistance\">desempleo</a>.",
@@ -358,7 +332,6 @@
   },
   "recovery_cant_work_items_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "If you are sick or hurt due to the fires, apply for <a href=\"https://edd.ca.gov/en/disability/disability_insurance/\">disability</a>",
     "fr": "Si vous êtes malade ou blessé à cause des incendies, faites une demande d'<a href=\"https://edd.ca.gov/en/disability/disability_insurance/\">allocation d'invalidité</a>",
     "es": "Si está enfermo o lesionado debido a los incendios, solicite los beneficios por <a href=\"https://edd.ca.gov/en/disability/disability_insurance/\">discapacidad</a>.",
@@ -372,7 +345,6 @@
   },
   "recovery_cant_work_items_3": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "If you need time off to care for your family and can’t work, apply for <a href=\"https://edd.ca.gov/en/disability/paid-family-leave/\">Paid Family Leave</a>",
     "fr": "Si vous avez besoin de temps libre pour vous occuper de votre famille et ne pouvez pas travailler, faites une demande de <a href=\"https://edd.ca.gov/en/disability/paid-family-leave/\">congé familial payé</a>",
     "es": "Si necesita una licencia del trabajo para cuidar a su familia y no puede trabajar, solicite un <a href=\"https://edd.ca.gov/en/disability/paid-family-leave/\">permiso de ausencia remunerada por motivos familiares</a>.",
@@ -386,7 +358,6 @@
   },
   "recovery_looking_for_work_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "If you’re looking for new work",
     "fr": "Si vous cherchez un nouveau travail",
     "es": "Si está buscando trabajo nuevo",
@@ -399,7 +370,6 @@
   },
   "recovery_looking_for_work_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "We have resources to assist you in finding employment after the wildfire. You may qualify for job placement services, training programs, or other help. The Employment Development Department (EDD) offers this support.",
     "fr": "Nous avons des ressources pour vous aider à trouver un emploi après l'incendie de forêt. Vous pourriez être admissible à des services de placement, des programmes de formation ou d'autres aides. Le Département du développement de l'emploi (EDD) offre ce soutien.",
     "es": "Tenemos recursos para ayudarle a encontrar empleo después del incendio. Es posible que califique para servicios de colocación laboral, programas de capacitación u otra ayuda. El Departamento de Desarrollo de Empleo (Employment Development Department, EDD) ofrece este apoyo.",
@@ -412,7 +382,6 @@
   },
   "recovery_looking_for_work_items_1": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "Apply for a new job on <a href=\"https://www.caljobs.ca.gov/vosnet/default.aspx\">CalJOBS</a>, California’s online job exchange system.",
     "fr": "Postulez pour un nouvel emploi sur <a href=\"https://www.caljobs.ca.gov/vosnet/default.aspx\">CalJOBS</a>, le système d'échange d'emplois en ligne de la Californie.",
     "es": "Busque un nuevo trabajo en <a href=\"https://www.caljobs.ca.gov/vosnet/default.aspx\">CalJOBS</a>, el sistema de intercambio de trabajo en línea de California.",
@@ -426,7 +395,6 @@
   },
   "recovery_looking_for_work_items_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "<a href=\"https://edd.ca.gov/en/jobs/\">Jobs and training</a> has general support, referrals, and training to find a new job in California.",
     "fr": "<a href=\"https://edd.ca.gov/en/jobs/\">Emplois et formation</a> offre un soutien général, des références et de la formation pour trouver un nouvel emploi en Californie.",
     "es": "<a href=\"https://edd.ca.gov/en/jobs/\">La sección de empleos y capacitación</a> ofrece apoyo general, referencias y capacitación para encontrar un nuevo trabajo en California.",
@@ -440,7 +408,6 @@
   },
   "recovery_cleanup_work_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "If you’re working on fire cleanup",
     "fr": "Si vous travaillez au nettoyage après l'incendie",
     "es": "Si está trabajando en la limpieza de los incendios",
@@ -453,7 +420,6 @@
   },
   "recovery_cleanup_work_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "If you have a job where you’re cleaning up from the fires, your employer must protect you.",
     "fr": "Si vous avez un emploi où vous nettoyez après les incendies, votre employeur doit vous protéger.",
     "es": "Si tiene un trabajo en el que debe limpiar después de un incendio, su empleador debe protegerlo.",
@@ -466,7 +432,6 @@
   },
   "recovery_cleanup_work_items_1": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "Read about how to stay <a href=\"https://www.labor.ca.gov/2025/02/06/know-your-rights-keep-yourself-safe-working-on-fire-cleanup/\">safe while working on fire cleanup</a>",
     "fr": "Lisez comment rester <a href=\"https://www.labor.ca.gov/2025/02/06/know-your-rights-keep-yourself-safe-working-on-fire-cleanup/\">en sécurité pendant le nettoyage après l'incendie</a>",
     "es": "Lea sobre cómo mantenerse seguro mientras <a href=\"https://www.labor.ca.gov/2025/02/06/know-your-rights-keep-yourself-safe-working-on-fire-cleanup/\">trabaja en la limpieza de los incendios</a>",
@@ -480,7 +445,6 @@
   },
   "recovery_cleanup_work_items_2": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "See <a href=\"https://www.ca.gov/departments/91/services/1279/\">what laws protect cleanup and rebuilding workers</a>",
     "fr": "Consultez <a href=\"https://www.ca.gov/departments/91/services/1279/\">les lois qui protègent les travailleurs du nettoyage et de la reconstruction</a>",
     "es": "Vea <a href=\"https://www.ca.gov/departments/91/services/1279/\">qué leyes protegen a los trabajadores de limpieza y reconstrucción</a>",
@@ -494,7 +458,6 @@
   },
   "recovery_taxes_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "Taxes for individuals",
     "fr": "Impôts pour les particuliers",
     "es": "Impuestos para individuos",
@@ -507,7 +470,6 @@
   },
   "recovery_income_tax_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "Income tax",
     "fr": "Impôt sur le revenu",
     "es": "Impuesto sobre los ingresos",
@@ -520,7 +482,6 @@
   },
   "recovery_income_tax_source": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "by Franchise Tax Board",
     "fr": "par le Conseil des impôts",
     "es": "de la Junta de Impuestos de Franquicias",
@@ -533,7 +494,6 @@
   },
   "recovery_income_tax_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "People in Los Angeles County affected by the fires may <a href=\"https://www.ftb.ca.gov/file/when-to-file/los-angeles-county-fires.html\">postpone filing and paying taxes</a>. Their new deadline is October 15, 2025.",
     "fr": "Les personnes du comté de Los Angeles touchées par les incendies peuvent <a href=\"https://www.ftb.ca.gov/file/when-to-file/los-angeles-county-fires.html\">reporter le dépôt et le paiement des impôts</a>. Leur nouvelle date limite est le 15 octobre 2025.",
     "es": "Las personas en el condado de Los Ángeles afectadas por los incendios pueden <a href=\"https://www.ftb.ca.gov/file/when-to-file/los-angeles-county-fires.html\">posponer la presentación y el pago de impuestos</a>. Su nueva fecha límite es el 15 de octubre de 2025.",
@@ -547,7 +507,6 @@
   },
   "recovery_property_tax_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "Property tax",
     "fr": "Impôt foncier",
     "es": "Impuesto sobre la propiedad",
@@ -560,7 +519,6 @@
   },
   "recovery_property_tax_source": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "by the State of California and LA County",
     "fr": "par l'État de Californie et le comté de LA",
     "es": "del condado de Los Ángeles y el estado de California",
@@ -573,7 +531,6 @@
   },
   "recovery_property_tax_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/start-your-recovery-shared.html",
     "en": "The state <a href=\"https://www.gov.ca.gov/2025/01/16/governor-newsom-extends-state-property-tax-deadlines-for-la-firestorm-communities-until-april-2026/\">extended the property tax deadline</a> for people affected by the LA fires. You can apply for property tax reassessment with the <a href=\"https://assessor.lacounty.gov/tax-relief/disaster-relief\">Los Angeles County Assessor</a>. Learn more about <a href=\"https://www.boe.ca.gov/proptaxes/disaster-relief.htm\">property tax reassessments and base year value transfers</a>.",
     "fr": "L'État a <a href=\"https://www.gov.ca.gov/2025/01/16/governor-newsom-extends-state-property-tax-deadlines-for-la-firestorm-communities-until-april-2026/\">prolongé la date limite de l'impôt foncier</a> pour les personnes touchées par les incendies de LA. Vous pouvez demander une réévaluation de l'impôt foncier auprès de l'<a href=\"https://assessor.lacounty.gov/tax-relief/disaster-relief\">évaluateur du comté de Los Angeles</a>. En savoir plus sur les <a href=\"https://www.boe.ca.gov/proptaxes/disaster-relief.htm\">réévaluations de l'impôt foncier et les transferts de valeur de l'année de base</a>.",
     "es": "El estado <a href=\"https://www.gov.ca.gov/2025/01/16/governor-newsom-extends-state-property-tax-deadlines-for-la-firestorm-communities-until-april-2026/\">extendió la fecha límite de pago del impuesto a la propiedad</a> para las personas afectadas por los incendios de Los Ángeles. Puede solicitar una <a href=\"https://assessor.lacounty.gov/tax-relief/disaster-relief\">reevaluación</a> de impuestos sobre la propiedad con el <a href=\"https://assessor.lacounty.gov/tax-relief/disaster-relief\">asesor del condado de Los Ángeles</a>. Obtenga más información sobre <a href=\"https://www.boe.ca.gov/proptaxes/disaster-relief.htm\">las reevaluaciones de impuestos a la propiedad y las transferencias de valor del año base</a>.",

--- a/src/_data/i18n/i18n-stay-healthy.json
+++ b/src/_data/i18n/i18n-stay-healthy.json
@@ -1,7 +1,6 @@
 {
   "stay_healthy_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Stay healthy",
     "fr": "Restez en bonne santé",
     "es": "Mantenerse saludable",
@@ -14,7 +13,6 @@
   },
   "stay_healthy_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Find out how to stay healthy after a wildfire.",
     "fr": "Découvrez comment rester en bonne santé après un feu de forêt.",
     "es": "Aprenda cómo mantenerse saludable después de un incendio forestal.",
@@ -27,7 +25,6 @@
   },
   "stay_healthy_keywords": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "California, government, LA, Los Angeles, fires, wildfires, air safety, water safety",
     "fr": "Californie, gouvernement, LA, Los Angeles, incendies, feux de forêt, sécurité de l'air, sécurité de l'eau",
     "es": "California, gobierno, LA, Los Ángeles, incendios, seguridad del aire, seguridad del agua",
@@ -40,7 +37,6 @@
   },
   "stay_healthy_lead_text": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Learn how to stay safe and healthy during recovery.",
     "fr": "Apprenez comment rester en sécurité et en bonne santé pendant la période de rétablissement.",
     "es": "Obtenga información sobre cómo mantenerse seguro y saludable durante la recuperación.",
@@ -53,7 +49,6 @@
   },
   "stay_healthy_air_safety_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Air safety",
     "fr": "Sécurité de l'air",
     "es": "Seguridad del aire",
@@ -66,7 +61,6 @@
   },
   "stay_healthy_understand_air_quality": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Understand air quality and how to protect yourself from toxins.",
     "fr": "Comprendre la qualité de l'air et comment se protéger des toxines.",
     "es": "Comprenda la calidad del aire y cómo protegerse de las toxinas.",
@@ -79,7 +73,6 @@
   },
   "stay_healthy_outdoor_air_quality_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Outdoor air quality",
     "fr": "Qualité de l'air extérieur",
     "es": "Calidad del aire en exteriores",
@@ -92,7 +85,6 @@
   },
   "stay_healthy_outdoor_air_quality": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Now that the fires are out, air quality has improved. But you can check the <a href=\"https://www.aqmd.gov/\">air quality index (AQI)</a> from South Coast Air Quality Monitoring District.",
     "fr": "Maintenant que les incendies sont éteints, la qualité de l'air s'est améliorée. Mais vous pouvez vérifier l'<a href=\"https://www.aqmd.gov/\">indice de qualité de l'air (IQA)</a> du district de surveillance de la qualité de l'air de la côte sud.",
     "es": "Ahora que se han apagado los incendios, la calidad del aire ha mejorado. Pero puede revisar el <a href=\"https://www.aqmd.gov/\">índice de calidad del aire</a> del Distrito de Monitoreo de la Calidad del Aire de la Costa Sur.",
@@ -106,7 +98,6 @@
   },
   "stay_healthy_air_quality_monitoring": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "See <a href=\"/lafires/track-progress/#Air-quality\">how air quality is monitored in your area</a>.",
     "fr": "Voir <a href=\"/lafires/fr/track-progress/#Air-quality\">comment la qualité de l'air est surveillée dans votre région</a>.",
     "es": "Vea <a href=\"/lafires/es/track-progress/#Air-quality\">cómo se monitorea la calidad del aire en su área</a>.",
@@ -120,7 +111,6 @@
   },
   "stay_healthy_indoor_air_quality_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Indoor air quality",
     "fr": "Qualité de l'air intérieur",
     "es": "Calidad del aire en interiores",
@@ -133,7 +123,6 @@
   },
   "stay_healthy_indoor_air_quality": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "There may be toxins still in your home from smoke and ash. Wear a respirator and other protection when you return home.",
     "fr": "Il peut encore y avoir des toxines dans votre maison provenant de la fumée et des cendres. Portez un respirateur et d'autres protections lorsque vous rentrez chez vous.",
     "es": "Es posible que aún haya toxinas en su hogar por el humo y las cenizas. Use un aparato respiratorio y otras protecciones cuando regrese a casa.",
@@ -146,7 +135,6 @@
   },
   "stay_healthy_water_safety_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Water safety",
     "fr": "Sécurité de l'eau",
     "es": "Seguridad del agua",
@@ -159,7 +147,6 @@
   },
   "stay_healthy_water_safety": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "The fires contaminated some water systems. Find the <a href=\"https://www.waterboards.ca.gov/water_issues/programs/emp/wildfire_recovery/\">latest information on water safety</a> from your water provider. Check your water bill to find your provider. If you’re a renter, ask your landlord.",
     "fr": "Les incendies ont contaminé certains systèmes d'eau. Trouvez les <a href=\"https://www.waterboards.ca.gov/water_issues/programs/emp/wildfire_recovery/\">dernières informations sur la sécurité de l'eau</a> auprès de votre fournisseur d'eau. Vérifiez votre facture d'eau pour trouver votre fournisseur. Si vous êtes locataire, demandez à votre propriétaire.",
     "es": "Los incendios contaminaron algunos sistemas de agua. Encuentre la <a href=\"https://www.waterboards.ca.gov/water_issues/programs/emp/wildfire_recovery/\">información más reciente sobre la seguridad del agua</a> de su proveedor de agua. Revise su factura de agua para encontrar a su proveedor. Si usted alquila su hogar, pregúntele al propietario.",
@@ -173,7 +160,6 @@
   },
   "stay_healthy_water_safety_notice": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "If your water provider sent a notice, your water may not be safe to use, drink, or boil. If you got a notice like that, use bottled water for:",
     "fr": "Si votre fournisseur d'eau a envoyé un avis, votre eau peut ne pas être sûre à utiliser, à boire ou à faire bouillir. Si vous avez reçu un tel avis, utilisez de l'eau en bouteille pour :",
     "es": "Si su proveedor de agua le envió una notificación, es posible que su agua no sea segura para usar, beber o hervir. Si recibió un aviso como este, use agua embotellada para:",
@@ -186,7 +172,6 @@
   },
   "stay_healthy_drinking": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Drinking",
     "fr": "Boire",
     "es": "beber",
@@ -199,7 +184,6 @@
   },
   "stay_healthy_baby_formula": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Baby formula",
     "fr": "Préparation pour nourrissons",
     "es": "preparar fórmula para bebés",
@@ -212,7 +196,6 @@
   },
   "stay_healthy_brushing_teeth": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Brushing teeth",
     "fr": "Se brosser les dents",
     "es": "cepillarse los dientes",
@@ -225,7 +208,6 @@
   },
   "stay_healthy_washing_dishes": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Washing dishes",
     "fr": "Laver la vaisselle",
     "es": "lavar los platos",
@@ -238,7 +220,6 @@
   },
   "stay_healthy_making_ice": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Making ice",
     "fr": "Faire des glaçons",
     "es": "hacer hielo",
@@ -251,7 +232,6 @@
   },
   "stay_healthy_preparing_food": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Preparing food",
     "fr": "Préparer la nourriture",
     "es": "preparar su comida",
@@ -264,7 +244,6 @@
   },
   "stay_healthy_feeding_pets": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Feeding pets",
     "fr": "Nourrir les animaux domestiques",
     "es": "dar de beber o preparar el alimento de sus mascotas",
@@ -277,7 +256,6 @@
   },
   "stay_healthy_water_notice_lifted": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "If your water provider lifted the water notice in your area, you can use tap water again. <a href=\"https://www.ladwp.com/publications/newsletters/articles/guide-flushing-water-pipes\">Flush your water pipes</a> to clear the contaminated water from your home. Keep in mind that home water testing kits aren’t reliable.",
     "fr": "Si votre fournisseur d'eau a levé l'avis concernant l'eau dans votre région, vous pouvez à nouveau utiliser l'eau du robinet. <a href=\"https://www.ladwp.com/publications/newsletters/articles/guide-flushing-water-pipes\">Rincez vos canalisations</a> pour éliminer l'eau contaminée de votre maison. Gardez à l'esprit que les kits de test d'eau domestique ne sont pas fiables.",
     "es": "Si su proveedor de agua dio de baja la notificación de agua en su área, puede volver a usar agua del grifo. <a href=\"https://www.ladwp.com/publications/newsletters/articles/guide-flushing-water-pipes\">Descargue el agua de las tuberías</a> para eliminar el agua contaminada de su hogar. Tenga en cuenta que los kits de prueba de agua para el hogar no son confiables.",
@@ -291,7 +269,6 @@
   },
   "stay_healthy_beach_water_quality": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Also, check for <a href=\"http://publichealth.lacounty.gov/phcommon/public/eh/water_quality/beach_grades.cfm/\">beach water quality advisories</a>. Rain can wash toxins from the fires into the ocean.",
     "fr": "Vérifiez également les <a href=\"http://publichealth.lacounty.gov/phcommon/public/eh/water_quality/beach_grades.cfm/\">avis sur la qualité de l'eau des plages</a>. La pluie peut entraîner les toxines des incendies dans l'océan.",
     "es": "Además, consulte los <a href=\"http://publichealth.lacounty.gov/phcommon/public/eh/water_quality/beach_grades.cfm/\">avisos sobre la calidad del agua de la playa</a>. La lluvia puede arrastrar las toxinas de los incendios al mar.",
@@ -305,7 +282,6 @@
   },
   "stay_healthy_staying_safe_at_home_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Staying safe at home",
     "fr": "Rester en sécurité à la maison",
     "es": "Quédese a salvo en casa",
@@ -318,7 +294,6 @@
   },
   "stay_healthy_staying_safe_at_home_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Once you get a pass to return home, be aware of toxic materials and ash.",
     "fr": "Une fois que vous avez l'autorisation de rentrer chez vous, faites attention aux matériaux toxiques et aux cendres.",
     "es": "Una vez que obtenga la autorización para regresar a casa, tenga en cuenta los materiales tóxicos y las cenizas.",
@@ -331,7 +306,6 @@
   },
   "stay_healthy_clearing_hazardous_waste_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Clearing hazardous waste",
     "fr": "Élimination des déchets dangereux",
     "es": "Quitar los residuos peligrosos",
@@ -344,7 +318,6 @@
   },
   "stay_healthy_clearing_hazardous_waste_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "The EPA has removed household hazardous waste from burned properties.",
     "fr": "L'EPA a retiré les déchets dangereux domestiques des propriétés brûlées.",
     "es": "La Agencia de Protección Ambiental (Environmental Protection Agency, EPA) retiró los residuos peligrosos de las propiedades que se quemaron.",
@@ -357,7 +330,6 @@
   },
   "stay_healthy_hazardous_waste_removal_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "They removed toxic and explosive materials they can see. This includes things like paints, batteries, and propane tanks. This service was automatic and there’s no cost to you.",
     "fr": "Ils ont retiré les matériaux toxiques et explosifs visibles. Cela comprend des choses comme les peintures, les batteries et les réservoirs de propane. Ce service était automatique et gratuit pour vous.",
     "es": "Retiró los materiales tóxicos y explosivos que se podían ver. Esto incluye cosas como pinturas, baterías y tanques de propano. Este servicio se hizo de forma automática y no implicó ningún costo para usted.",
@@ -370,7 +342,6 @@
   },
   "stay_healthy_hazardous_waste_removal_notice_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "If you still see hazardous waste after the EPA cleared your home, leave it alone. It is toxic and could spark more fires. If you hear a popping or hissing noise or see smoke, leave the area immediately and call 911.",
     "fr": "Si vous voyez encore des déchets dangereux après que l'EPA ait nettoyé votre maison, ne les touchez pas. Ils sont toxiques et pourraient déclencher d'autres incendies. Si vous entendez un bruit de crépitement ou de sifflement ou si vous voyez de la fumée, quittez immédiatement la zone et appelez le 911.",
     "es": "Si aún ve residuos peligrosos después de que la EPA haya limpiado su hogar, no los toque. Son tóxicos y pueden provocar más incendios. Si escucha un chasquido o ve humo, abandone el área de inmediato y llame al 911.",
@@ -383,7 +354,6 @@
   },
   "stay_healthy_worker_safety_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "If you are a worker at a fire cleanup site, find out how to <a href=\"https://www.dir.ca.gov/wildfire-faq.html\">stay safe while you work</a>.",
     "fr": "Si vous êtes un travailleur sur un site de nettoyage d'incendie, découvrez comment <a href=\"https://www.dir.ca.gov/wildfire-faq.html\">rester en sécurité pendant votre travail</a>.",
     "es": "Si usted es trabajador en un sitio de limpieza de incendios, descubra cómo <a href=\"https://www.dir.ca.gov/wildfire-faq.html\">mantenerse seguro mientras trabaja</a>.",
@@ -397,7 +367,6 @@
   },
   "stay_healthy_learn_more_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Learn more about the <a href=\"https://file.lacounty.gov/SDSInter/lac/1176389_EPAPhaseIHouseholdHazardousWasteFactSheet.pdf\">EPA cleanup</a> and the <a href=\"/lafires/accessing-your-property/\">next cleanup phase</a>.",
     "fr": "En savoir plus sur le <a href=\"https://file.lacounty.gov/SDSInter/lac/1176389_EPAPhaseIHouseholdHazardousWasteFactSheet.pdf\">nettoyage de l'EPA</a> et la <a href=\"/lafires/fr/accessing-your-property/\">prochaine phase de nettoyage</a>.",
     "es": "Obtenga más información sobre la <a href=\"https://file.lacounty.gov/SDSInter/lac/1176389_EPAPhaseIHouseholdHazardousWasteFactSheet.pdf\">limpieza de la EPA </a> y la <a href=\"/lafires/es/accessing-your-property/\">próxima fase de limpieza</a>.",
@@ -411,7 +380,6 @@
   },
   "stay_healthy_ash_dust_and_debris_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Ash, dust, and debris",
     "fr": "Cendres, poussière et débris",
     "es": "Ceniza, polvo y escombros",
@@ -424,7 +392,6 @@
   },
   "stay_healthy_ash_dust_and_debris_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Protect yourself from ash, dust, and debris. They may contain toxic and cancer-causing chemicals like asbestos, arsenic, and lead. Limit contact with these materials.",
     "fr": "Protégez-vous des cendres, de la poussière et des débris. Ils peuvent contenir des produits chimiques toxiques et cancérigènes comme l'amiante, l'arsenic et le plomb. Limitez le contact avec ces matériaux.",
     "es": "Protéjase de la ceniza, el polvo y los escombros. Pueden tener sustancias químicas tóxicas y cancerígenas, como asbesto, arsénico y plomo. Limite el contacto con estos materiales.",
@@ -437,7 +404,6 @@
   },
   "stay_healthy_sensitive_groups_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Some groups are more sensitive to these materials. They should stay away from debris and the cleanup. They include:",
     "fr": "Certains groupes sont plus sensibles à ces matériaux. Ils doivent rester à l'écart des débris et du nettoyage. Ils comprennent :",
     "es": "Algunos grupos son más sensibles a estos materiales. Deberían permanecer lejos de los escombros y la limpieza. Estos grupos incluyen:",
@@ -450,7 +416,6 @@
   },
   "stay_healthy_people_with_heart_or_lung_disease": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "People with heart or lung disease (like asthma)",
     "fr": "Les personnes atteintes de maladies cardiaques ou pulmonaires (comme l'asthme)",
     "es": "personas con enfermedad cardíaca o pulmonar (como asma)",
@@ -463,7 +428,6 @@
   },
   "stay_healthy_older_adults": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Older adults",
     "fr": "Les personnes âgées",
     "es": "adultos mayores",
@@ -476,7 +440,6 @@
   },
   "stay_healthy_pregnant_women": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Pregnant women",
     "fr": "Les femmes enceintes",
     "es": "mujeres embarazadas",
@@ -489,7 +452,6 @@
   },
   "stay_healthy_children": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Children",
     "fr": "Les enfants",
     "es": "niños",
@@ -502,7 +464,6 @@
   },
   "stay_healthy_pets": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Pets",
     "fr": "Les animaux domestiques",
     "es": "mascotas",
@@ -515,7 +476,6 @@
   },
   "stay_healthy_ash_dust_and_debris_clean_home": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "If you can see ash and smell smoke, you need to clean your home. No laboratory test can determine if your property is safe.",
     "fr": "Si vous pouvez voir des cendres et sentir la fumée, vous devez nettoyer votre maison. Aucun test de laboratoire ne peut déterminer si votre propriété est sûre.",
     "es": "Si puede ver la ceniza y oler el humo, debe limpiar su casa. Ninguna prueba de laboratorio puede determinar si su propiedad es segura.",
@@ -529,7 +489,6 @@
   "stay_healthy_ash_dust_and_debris_keep_ash_from_spreading": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Keep ash from spreading by wet mopping. Put debris and ash in a plastic trash bag and throw them away with your regular trash. If ash gets on your skin, wash with warm water and soap as soon as possible. Stay safe by wearing:",
     "fr": "Empêchez la propagation des cendres en passant la serpillière humide. Mettez les débris et les cendres dans un sac poubelle en plastique et jetez-les avec vos ordures habituelles. Si des cendres entrent en contact avec votre peau, lavez-vous à l'eau tiède et au savon dès que possible. Restez en sécurité en portant:",
     "es": "Evite que la ceniza se propague usando un trapeador húmedo. Coloque los escombros y la ceniza en una bolsa de basura de plástico y tírelos con su basura regular. Si la ceniza entra en contacto con su piel, lávese con agua tibia y jabón lo antes posible. Manténgase seguro usando:",
@@ -543,7 +502,6 @@
   "stay_healthy_n_100_or_p_100_respirator": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "N-100 or P-100 respirator",
     "fr": "Un respirateur N-100 ou P-100",
     "es": "Respirador N-100 o P-100",
@@ -557,7 +515,6 @@
   "stay_healthy_rubber_gloves": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Rubber gloves",
     "fr": "Des gants en caoutchouc",
     "es": "Guantes de goma",
@@ -571,7 +528,6 @@
   "stay_healthy_booties": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Booties",
     "fr": "Des sur-chaussures",
     "es": "Botitas protectoras",
@@ -585,7 +541,6 @@
   "stay_healthy_long_sleeved_shirts": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Long-sleeved shirts",
     "fr": "Des chemises à manches longues",
     "es": "Camisas de manga larga",
@@ -599,7 +554,6 @@
   "stay_healthy_long_pants": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Long pants",
     "fr": "Des pantalons longs",
     "es": "Pantalones largos",
@@ -613,7 +567,6 @@
   "stay_healthy_socks_and_shoes": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Socks and shoes",
     "fr": "Des chaussettes et des chaussures",
     "es": "Calcetines y zapatos",
@@ -627,7 +580,6 @@
   "stay_healthy_safety_goggles": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Safety goggles (not glasses)",
     "fr": "Des lunettes de sécurité (pas des lunettes ordinaires)",
     "es": "Gafas de seguridad (no anteojos normales)",
@@ -641,7 +593,6 @@
   "stay_healthy_n95_masks_cannot_protect_from_asbestos": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "N95 masks cannot protect you from asbestos. Learn more about the <a href=\"https://www.dir.ca.gov/dosh/fire_resp_protection.html\">respiratorsthat can protect you</a>. You can get personal protective equipment at a <a href=\"/lafires/get-help-in-person/\">Disaster Recovery Center</a>.",
     "fr": "Les masques N95 ne peuvent pas vous protéger de l'amiante. En savoir plus sur les <a href=\"https://www.dir.ca.gov/dosh/fire_resp_protection.html\">respirateurs qui peuvent vous protéger</a>. Vous pouvez obtenir des équipements de protection individuelle dans un <a href=\"/lafires/fr/get-help-in-person/\">Centre de rétablissement après sinistre</a>.",
     "es": "Las mascarillas N95 no pueden protegerlo del asbesto. Obtenga más información sobre los <a href=\"https://www.dir.ca.gov/dosh/fire_resp_protection.html\">respiradores que pueden protegerlo</a>. Puede obtener equipo de protección personal en un <a href=\"/lafires/es/get-help-in-person/\">Centro de Recuperación por Desastre</a>.",
@@ -655,7 +606,6 @@
   "stay_healthy_dealing_with_dust_and_debris_when_returning_home": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Learn more about <a href=\"https://recovery.lacounty.gov/returning-after-a-fire-public-health\">dealing with dust and debris</a> when returning home.",
     "fr": "En savoir plus sur la <a href=\"https://recovery.lacounty.gov/returning-after-a-fire-public-health\">gestion de la poussière et des débris</a> lors du retour à la maison.",
     "es": "Obtenga más información sobre cómo <a href=\"https://recovery.lacounty.gov/returning-after-a-fire-public-health\">manejar el polvo y los escombros</a> al regresar a casa.",
@@ -669,7 +619,6 @@
   "stay_healthy_health_and_wellness_heading": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Health and wellness",
     "fr": "Santé et bien-être",
     "es": "Salud y bienestar",
@@ -683,7 +632,6 @@
   "stay_healthy_medical_help_heading": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Medical help",
     "fr": "Aide médicale",
     "es": "Ayuda médica",
@@ -697,7 +645,6 @@
   "stay_healthy_medical_help_description": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "<a href=\"https://aspr.hhs.gov/EPAP/Pages/epap-for-patients.aspx\">Get the medicine you need</a> through the federal Emergency Prescription Assistance Program. This program helps people without insurance replace prescriptions or medical equipment.",
     "fr": "<a href=\"https://aspr.hhs.gov/EPAP/Pages/epap-for-patients.aspx\">Obtenez les médicaments dont vous avez besoin</a> grâce au Programme fédéral d'assistance aux prescriptions d'urgence. Ce programme aide les personnes sans assurance à remplacer leurs prescriptions ou leur équipement médical.",
     "es": "<a href=\"https://aspr.hhs.gov/EPAP/Pages/epap-for-patients.aspx\">Obtenga los medicamentos que necesita</a> a través del Programa Federal de Asistencia para Medicamentos de Emergencia. Este programa ayuda a las personas sin seguro a reemplazar recetas o equipo médico.",
@@ -711,7 +658,6 @@
   "stay_healthy_get_help_in_person_description": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Get help in person at a <a href=\"/lafires/get-help-in-person/\">Disaster Recovery Center</a>. Nurses can connect you with referrals and access to medications.",
     "fr": "Obtenez de l'aide en personne dans un <a href=\"/lafires/fr/get-help-in-person/\">Centre de rétablissement après sinistre</a>. Les infirmières peuvent vous mettre en relation avec des références et l'accès aux médicaments.",
     "es": "Obtenga ayuda en persona en un <a href=\"/lafires/es/get-help-in-person/\">Centro de Recuperación por Desastre</a>. Las enfermeras pueden conectarlo con referencias y acceso a medicamentos.",
@@ -725,7 +671,6 @@
   "stay_healthy_health_insurance_description": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "If you need health insurance, you may be able to get <a href=\"https://dpss.lacounty.gov/en/health.html\">Medi-Cal</a>.",
     "fr": "Si vous avez besoin d'une assurance maladie, vous pourriez être éligible à <a href=\"https://dpss.lacounty.gov/en/health.html\">Medi-Cal</a>.",
     "es": "Si necesita seguro médico, es posible que pueda obtener <a href=\"https://dpss.lacounty.gov/en/health.html\">Medi-Cal</a>.",
@@ -739,7 +684,6 @@
   "stay_healthy_mental_health_heading": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Mental health",
     "fr": "Santé mentale",
     "es": "Salud mental",
@@ -753,7 +697,6 @@
   "stay_healthy_mental_health_description": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Navigating disaster recovery is stressful and overwhelming. Get mental and emotional support for yourself and your loved ones.",
     "fr": "Naviguer dans le rétablissement après un sinistre est stressant et accablant. Obtenez un soutien mental et émotionnel pour vous-même et vos proches.",
     "es": "Navegar por la recuperación de desastres es estresante y abrumador. Obtenga apoyo mental y emocional para usted y sus seres queridos.",
@@ -767,7 +710,6 @@
   "stay_healthy_calhope_warm_line_description": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Call the <a href=\"https://www.calhope.org/\">CalHOPE Warm Line</a>, a 24/7 peer-run hotline. It gives free and confidential emotional support. Find more <a href=\"https://www.cdph.ca.gov/Programs/EPO/Pages/Wildfire%20Pages/Wildfires--Mental-Health.aspx\">free and confidential support</a> for youth and adults.",
     "fr": "Appelez la <a href=\"https://www.calhope.org/\">ligne d'assistance CalHOPE</a>, une ligne d'assistance gérée par des pairs disponible 24h/24 et 7j/7. Elle offre un soutien émotionnel gratuit et confidentiel. Trouvez plus de <a href=\"https://www.cdph.ca.gov/Programs/EPO/Pages/Wildfire%20Pages/Wildfires--Mental-Health.aspx\">soutien gratuit et confidentiel</a> pour les jeunes et les adultes.",
     "es": "Llame a la <a href=\"https://www.calhope.org/\">Línea de Apoyo CalHOPE</a>, una línea directa atendida por pares las 24 horas del día, los 7 días de la semana. Brinda apoyo emocional gratuito y confidencial. Encuentre más <a href=\"https://www.cdph.ca.gov/Programs/EPO/Pages/Wildfire%20Pages/Wildfires--Mental-Health.aspx\">apoyo gratuito y confidencial</a> para jóvenes y adultos.",
@@ -781,7 +723,6 @@
   "stay_healthy_employee_assistance_program_description": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Check if your workplace has an Employee Assistance Program. They may offer confidential counseling and support.",
     "fr": "Vérifiez si votre lieu de travail dispose d'un Programme d'aide aux employés. Ils peuvent offrir des conseils et un soutien confidentiels.",
     "es": "Verifique si su lugar de trabajo tiene un Programa de Asistencia al Empleado. Pueden ofrecer asesoramiento y apoyo confidencial.",
@@ -795,7 +736,6 @@
   "stay_healthy_benefits_for_disaster_injuries_heading": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "Benefits for disaster injuries",
     "fr": "Prestations pour les blessures liées aux catastrophes",
     "es": "Beneficios por lesiones por desastres",
@@ -809,7 +749,6 @@
   "stay_healthy_benefits_for_disaster_injuries_description": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "If you or your loved ones have injuries from the wildfires, you may be eligible for benefits.",
     "fr": "Si vous ou vos proches avez des blessures causées par les feux de forêt, vous pourriez être éligible à des prestations.",
     "es": "Si usted o sus seres queridos tienen lesiones por los incendios forestales, puede ser elegible para beneficios.",
@@ -823,7 +762,6 @@
   "stay_healthy_disability_insurance_description": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "<a href=\"https://edd.ca.gov/en/disability/disability_insurance/\">Disability Insurance</a> provides short-term wages if an injury prevents you from working.",
     "fr": "L'<a href=\"https://edd.ca.gov/en/disability/disability_insurance/\">assurance invalidité</a> fournit des salaires à court terme si une blessure vous empêche de travailler.",
     "es": "El <a href=\"https://edd.ca.gov/en/disability/disability_insurance/\">Seguro de Discapacidad</a> proporciona salarios a corto plazo si una lesión le impide trabajar.",
@@ -837,7 +775,6 @@
   "stay_healthy_paid_family_leave_description": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/stay-healthy-shared.html",
     "en": "<a href=\"https://edd.ca.gov/en/disability/paid-family-leave/\">Paid Family Leave</a> provides benefits if you need to take time off work to care for a seriously ill family member.",
     "fr": "Le <a href=\"https://edd.ca.gov/en/disability/paid-family-leave/\">congé familial payé</a> fournit des prestations si vous devez prendre un congé pour vous occuper d'un membre de la famille gravement malade.",
     "es": "La <a href=\"https://edd.ca.gov/en/disability/paid-family-leave/\">Licencia Familiar Pagada</a> proporciona beneficios si necesita tomar tiempo libre del trabajo para cuidar a un familiar gravemente enfermo.",

--- a/src/_data/i18n/i18n-steps.json
+++ b/src/_data/i18n/i18n-steps.json
@@ -1,7 +1,6 @@
 {
   "steps_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "Steps to rebuilding",
     "es": "Pasos para la reconstrucción",
     "ko": "복구 단계",
@@ -13,7 +12,6 @@
   },
   "steps_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "See the major steps to take when rebuilding your home.",
     "es": "Consulte los pasos principales a seguir cuando reconstruya su hogar.",
     "ko": "주택을 복구할 때 취해야 할 주요 단계를 확인하십시오.",
@@ -25,7 +23,6 @@
   },
   "steps_lead_text": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "See the major steps to take when rebuilding your home.",
     "es": "Consulte los pasos principales a seguir cuando reconstruya su hogar.",
     "ko": "주택을 복구할 때 취해야 할 주요 단계를 확인하십시오.",
@@ -37,7 +34,6 @@
   },
   "steps_file_insurance_claims_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "File insurance claims",
     "es": "Presentar reclamos de seguro",
     "ko": "보험금 청구",
@@ -49,7 +45,6 @@
   },
   "steps_file_insurance_claims_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "If you have insurance, <strong>file a claim now</strong>.",
     "es": "Si tiene seguro, <strong>presente un reclamo ahora</strong>.",
     "ko": "보험에 가입한 경우 <strong>보험금을 청구하십시오</strong>.",
@@ -62,7 +57,6 @@
   },
   "steps_document_and_track_recovery_expenses": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "Make sure you document and track all recovery expenses.",
     "es": "Asegúrese de documentar y hacer un seguimiento de todos los gastos de recuperación.",
     "ko": "모든 복구 비용을 기록하고 확인할 수 있어야 합니다.",
@@ -74,7 +68,6 @@
   },
   "steps_temporary_housing_coverage": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "Your insurance may also cover at least 4 months of rent for temporary housing.",
     "es": "Su seguro también puede cubrir al menos cuatro meses de alquiler de vivienda temporal.",
     "ko": "가입하신 보험 또한 임시 주택에 대해 최소 4개월의 임대료를 보장해 드릴 수 있습니다.",
@@ -86,7 +79,6 @@
   },
   "steps_insurance_claims_help": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "If you need help with insurance claims,",
     "es": "Si necesita ayuda con reclamos de seguro:",
     "ko": "보험금 청구 관련 도움이 필요한 경우",
@@ -98,7 +90,6 @@
   },
   "steps_insurance_claims_help_department_of_insurance": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "See help from the <a href=\"https://www.insurance.ca.gov/01-consumers/101-help/\">Department of Insurance</a>, or",
     "es": "consulte la ayuda del <a href=\"https://www.insurance.ca.gov/01-consumers/101-help/\">Departamento de Seguros</a>, o",
     "ko": "<a href=\"https://www.insurance.ca.gov/01-consumers/101-help/\">보험국</a>의 지원 받기 또는",
@@ -112,7 +103,6 @@
   "steps_insurance_claims_help_call_number": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "Call <a href=\"tel:1-800-927-4357\">1-800-927-4357</a> or TTY: 711.",
     "es": "Llame al <a href=\"tel:1-800-927-4357\">1-800-927-4357</a> o TTY: 711.",
     "ko": "<a href=\"tel:1-800-927-4357\">1-800-927-4357</a> 또는 TTY: 711번으로 전화하십시오.",
@@ -124,7 +114,6 @@
   },
   "steps_get_money_to_rebuild": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "Get money to rebuild",
     "es": "Obtener dinero para reconstruir",
     "ko": "재건을 위한 재정 지원",
@@ -136,7 +125,6 @@
   },
   "steps_financial_support_to_rebuild": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "You may be eligible for financial support to help you rebuild.",
     "es": "Es posible que cumpla los requisitos para recibir apoyo financiero para ayudarle a reconstruir.",
     "ko": "재건에 도움이 되는 재정 지원을 받을 수 있습니다.",
@@ -149,7 +137,6 @@
   "steps_apply_for_fema_disaster_assistance": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "The deadline has passed to apply for <a href=\"https://disasterassistance.gov\">FEMA disaster assistance</a> (March 31, 2025).",
     "fr": "La date limite pour demander l'<a href=\"https://disasterassistance.gov\">aide de FEMA en cas de catastrophe</a> a passé (31 mars 2025).",
     "es": "La fecha límite para solicitar la <a href=\"https://disasterassistance.gov\">asistencia por desastre de FEMA</a> ha pasado (31 de marzo de 2025).",
@@ -163,7 +150,6 @@
   "steps_apply_for_disaster_loan": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "The deadline has also passed to apply for a <a href=\"https://lending.sba.gov/search-disaster\">disaster loan</a> from the Small Business Administration (March 31, 2025).",
     "fr": "La date limite pour demander un <a href=\"https://lending.sba.gov/search-disaster\">prêt en cas de catastrophe</a> de la Small Business Administration a passé (31 mars 2025).",
     "es": "La fecha límite para solicitar un <a href=\"https://lending.sba.gov/search-disaster\">préstamo por desastre</a> de la Administración de Pequeñas Empresas ha pasado (31 de marzo de 2025).",
@@ -176,7 +162,6 @@
   },
   "steps_contact_mortgage_lender": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "Contact your mortgage lender for mortgage relief. See this <a href=\"https://dfpi.ca.gov/lafires/relief/\">list of participating lenders</a>.",
     "es": "Comuníquese con su banco para asistencia con su hipoteca. Consulte esta <a href=\"https://dfpi.ca.gov/lafires/relief/\">lista de prestamistas participantes</a>.",
     "ko": "주택 담보 대출 구제에 대해서는 주택 담보 대출 기관에 문의하십시오. 이 <a href=\"https://dfpi.ca.gov/lafires/relief/\">참여 대출 기관 목록</a>을 참조하십시오.",
@@ -188,7 +173,6 @@
   },
   "steps_decide_how_to_remove_debris": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "Decide how to remove debris",
     "es": "Decidir cómo retirar los escombros",
     "ko": "잔해 제거 방법 결정",
@@ -201,7 +185,6 @@
   "steps_opt_in_for_free_debris_removal": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "Opt in to <a href=\"https://recovery.lacounty.gov/debris-removal/roe\">free debris removal</a> from the government by <strong>April 15, 2025</strong>.",
     "fr": "Inscrivez-vous à l'<a href=\"https://recovery.lacounty.gov/debris-removal/roe\">enlèvement gratuit des débris</a> par le gouvernement avant le <strong>15 avril 2025</strong>.",
     "es": "Opte por la <a href=\"https://recovery.lacounty.gov/debris-removal/roe\">remoción gratuita de escombros</a> del gobierno antes del <strong>15 de abril de 2025</strong>.",
@@ -214,7 +197,6 @@
   },
   "steps_pay_for_private_debris_removal": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "If you don’t opt in, you’ll need to pay for debris removal from a private contractor.",
     "fr": "Si vous ne vous inscrivez pas, vous devrez payer pour l'enlèvement des débris par un entrepreneur privé.",
     "es": "Si no opta por participar, tendrá que pagar por la remoción de escombros de un contratista privado.",
@@ -228,7 +210,6 @@
   "steps_learn_more_about_debris_removal": {
     "status": "avantpage_review",
     "comment": "links added",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "Learn <a href=\"/lafires/cleanup-and-debris-removal/\">more about debris removal</a>.",
     "es": "Obtenga más <a href=\"/lafires/es/cleanup-and-debris-removal/\">información sobre la remoción de escombros</a>.",
     "ko": "<a href=\"/lafires/ko/cleanup-and-debris-removal/\">잔해 제거에 대해 자세히</a> 알아보십시오.",
@@ -241,7 +222,6 @@
   },
   "steps_hire_a_contractor": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "Hire a contractor",
     "es": "Emplear a un contratista",
     "ko": "계약업체 고용",
@@ -253,7 +233,6 @@
   },
   "steps_use_state_licensed_contractor": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "Make sure you <a href=\"https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/ZipCodeSearch.aspx\">use a state-licensed contractor</a>.",
     "es": "Asegúrese de usar <a href=\"https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/ZipCodeSearch.aspx\">un contratista autorizado por el estado</a>.",
     "ko": "<a href=\"https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/ZipCodeSearch.aspx\">주정부 면허를 받은 계약업체</a>를 이용해야 합니다.",
@@ -266,7 +245,6 @@
   },
   "steps_get_written_contract": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "Get a written contract.",
     "es": "Obtenga un contrato por escrito.",
     "ko": "서면 계약을 체결하십시오.",
@@ -278,7 +256,6 @@
   },
   "steps_apply_for_permits": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "Apply for permits",
     "es": "Solicitud de autorización",
     "ko": "허가 신청",
@@ -290,7 +267,6 @@
   },
   "steps_submit_plans_and_apply_for_building_permits": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "You can submit your plans and <a href=\"https://epicla.lacounty.gov/energov_prod/SelfService/#/home\">apply for building permits</a> now. You don’t need to wait until debris removal is complete.",
     "es": "Puede enviar sus planos y <a href=\"https://epicla.lacounty.gov/energov_prod/SelfService/#/home\">solicitar permisos de construcción</a> ahora. No necesita esperar hasta que se complete la remoción de los escombros.",
     "ko": "지금 계획을 제출하고 <a href=\"https://epicla.lacounty.gov/energov_prod/SelfService/#/home\">복구 허가를</a> 신청할 수 있습니다. 잔해 제거가 완료될 때까지 기다릴 필요가 없습니다.",
@@ -303,7 +279,6 @@
   },
   "steps_apply_for_permits_in_person": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "You can also apply for permits in person at One-Stop Permit Centers. <a href=\"https://recovery.lacounty.gov/rebuilding/one-stop-permit-centers/\">Make an appointment</a>.",
     "es": "También puede solicitarlos personalmente en los Centros de Permiso One-Stop. <a href=\"https://recovery.lacounty.gov/rebuilding/one-stop-permit-centers/\">Programar una cita</a>.",
     "ko": "원스톱 허가 센터(One-Stop Permit Center)에서 직접 허가를 신청할 수도 있습니다. <a href=\"https://recovery.lacounty.gov/rebuilding/one-stop-permit-centers/\">신청 및 상담 일정을 잡으십시오</a>.",
@@ -316,7 +291,6 @@
   },
   "steps_apply_for_temporary_housing_permit": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "You can <a href=\"https://recovery.lacounty.gov/rebuilding/temporary-housing/\">apply to put temporary housing</a> on your property.",
     "es": "Puede solicitar <a href=\"https://recovery.lacounty.gov/rebuilding/temporary-housing/\">una vivienda temporal</a> en su propiedad.",
     "ko": "귀하의 부동산에 <a href=\"https://recovery.lacounty.gov/rebuilding/temporary-housing/\">임시 주택 시설을 짓는 신청</a>을 할 수 있습니다.",
@@ -329,7 +303,6 @@
   },
   "steps_temporary_housing_permit_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "A permit will only be issued after Phase 2 debris clearing of your property.",
     "es": "Una autorización solamente se emitirá después de eliminar los residuos de la fase 2 de su propiedad.",
     "ko": "허가증은 귀하의 부동산에 대한 2단계 잔해 제거 후에만 발급됩니다.",
@@ -341,7 +314,6 @@
   },
   "steps_learn_more_about_permits": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "Learn <a href=\"https://recovery.lacounty.gov/rebuilding/\">more about permits</a>, including about:",
     "es": "Obtenga <a href=\"https://recovery.lacounty.gov/rebuilding/\">más información sobre las autorizaciones</a>, incluyendo:",
     "ko": "다음 사항을 포함하여 <a href=\"https://recovery.lacounty.gov/rebuilding/\">허가에 대해 자세히</a> 알아보십시오",
@@ -354,7 +326,6 @@
   },
   "steps_like_for_like_rebuilds": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "Like-for-like rebuilds",
     "es": "reconstrucciones iguales",
     "ko": "동일 사양의 복구",
@@ -366,7 +337,6 @@
   },
   "steps_temporary_housing": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "Temporary housing",
     "es": "vivienda temporal",
     "ko": "임시 주택",
@@ -378,7 +348,6 @@
   },
   "steps_zoning_maps": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "Zoning maps",
     "es": "mapas de zonificación",
     "ko": "구역 지도",
@@ -390,7 +359,6 @@
   },
   "steps_fees": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "Fees",
     "es": "honorarios",
     "ko": "수수료",
@@ -402,7 +370,6 @@
   },
   "steps_start_construction": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "Start construction",
     "es": "Inicio de la construcción",
     "ko": "공사 시작",
@@ -414,7 +381,6 @@
   },
   "steps_contractor_guidance": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/steps-to-rebuilding-shared.html",
     "en": "Your contractor can guide you through the construction process.",
     "es": "Su contratista puede guiarle a través del proceso de construcción.",
     "ko": "계약업체가 공사 진행 동안 필요한 정보를 안내해 드릴 수 있습니다.",

--- a/src/_data/i18n/i18n-stories.json
+++ b/src/_data/i18n/i18n-stories.json
@@ -2,7 +2,6 @@
   "story_99085_title": {
     "status": "ap_review",
     "comment": "machine_translated",
-    "src_file": "pages/lafires/",
     "en": "Federal government approves California’s request to expand LA fire debris removal program",
     "fr": "Le gouvernement fédéral approuve la demande de la Californie pour étendre le programme de nettoyage des débris des incendies de LA",
     "es": "El gobierno federal aprueba la solicitud de California para expandir el programa de limpieza de desechos de incendios de LA",
@@ -16,7 +15,6 @@
 "story_99078_title": {
     "status": "ap_review",
     "comment": "machine_translated",
-    "src_file": "pages/lafires/",
     "en": "California urges FEMA to add businesses, non-profits, and multi-family structures to LA fire debris cleanup",
     "fr": "La Californie demande à FEMA d'ajouter les entreprises, les associations sans but lucratif et les structures multi-familiales à la récupération des débris des incendies de LA",
     "es": "La California pide a FEMA que agregue negocios, organizaciones sin fines de lucro y estructuras de vivienda múltiple a la limpieza de desechos de incendios de LA",
@@ -30,7 +28,6 @@
 "story_99057_title": {
     "status": "ap_review",
     "comment": "machine_translated",
-    "src_file": "pages/lafires/",
     "en": "Governor Newsom signs executive order to build Los Angeles back faster, prevent future fires",
     "fr": "Le gouverneur Newsom signe une ordonnance exécutive pour reconstruire Los Angeles plus rapidement et prévenir les incendies futurs",
     "es": "El gobernador Newsom firma una orden ejecutiva para reconstruir Los Angeles más rápidamente y prevenir incendios futuros",
@@ -44,7 +41,6 @@
 "story_99042_title": {
     "status": "ap_review",
     "comment": "machine_translated", 
-    "src_file": "pages/lafires/",
     "en": "Assistance continues to flow to families and businesses as federal aid for LA fires tops $2 billion",
     "fr": "L'aide continue d'affluer vers les familles et les entreprises alors que l'aide fédérale pour les incendies de LA dépasse 2 milliards de dollars",
     "es": "La asistencia continúa fluyendo a familias y negocios mientras la ayuda federal para los incendios de LA supera los $2 mil millones",
@@ -59,7 +55,6 @@
 "story_99004_title": {
     "status": "ap_review",
     "comment": "machine_translated",
-    "src_file": "pages/lafires/",
     "en": "LA fires cleanup on-track as fastest major cleanup in American history continues with new milestones",
     "fr": "Le nettoyage des incendies de LA est en bonne voie alors que le nettoyage majeur le plus rapide de l'histoire américaine se poursuit avec de nouvelles étapes",
     "es": "La limpieza de los incendios de LA va por buen camino mientras continúa la limpieza más rápida en la historia estadounidense con nuevos hitos",
@@ -74,7 +69,6 @@
 "story_98928_title": {
     "status": "ap_review", 
     "comment": "machine_translated",
-    "src_file": "pages/lafires/",
     "en": "Governor Newsom continues supporting Los Angeles business, fire recovery workers with funding, educational workplace safety outreach",
     "fr": "Le gouverneur Newsom continue de soutenir les entreprises de Los Angeles et les travailleurs de la reprise après incendie avec des financements et des actions de sensibilisation à la sécurité au travail",
     "es": "El gobernador Newsom continúa apoyando a las empresas de Los Ángeles y a los trabajadores de recuperación de incendios con financiamiento y actividades educativas sobre seguridad en el lugar de trabajo",
@@ -89,7 +83,6 @@
 "story_98879_title": {
     "status": "ap_review",
     "comment": "machine_translated",
-    "src_file": "pages/lafires/",
     "en": "ICYMI: LA’s rebuilding and recovery efforts continue with support from Governor Newsom and LA Rises",
     "fr": "Au cas où vous l'auriez manqué : Les efforts de reconstruction et de rétablissement de LA se poursuivent avec le soutien du gouverneur Newsom et de LA Rises",
     "es": "Por si te lo perdiste: Los esfuerzos de reconstrucción y recuperación de LA continúan con el apoyo del gobernador Newsom y LA Rises",
@@ -104,7 +97,6 @@
 "story_98867_title": {
     "status": "ap_review",
     "comment": "machine_translated",
-    "src_file": "pages/lafires/",
     "en": "California deploys cutting-edge technologies for LA fires recovery with expanded NASA Jet Propulsion Laboratory partnership",
     "fr": "La Californie déploie des technologies de pointe pour la reprise après les incendies de LA avec un partenariat élargi avec le Laboratoire de propulsion par réaction de la NASA",
     "es": "California implementa tecnologías de vanguardia para la recuperación de los incendios de LA con una asociación ampliada con el Laboratorio de Propulsión a Chorro de la NASA",
@@ -119,7 +111,6 @@
 "story_98806_title": {
     "status": "ap_review",
     "comment": "machine_translated",
-    "src_file": "pages/lafires/",
     "en": "Governor Newsom announces deadline extension to apply for federal assistance for Los Angeles fires",
     "fr": "Le gouverneur Newsom annonce la prolongation du délai pour demander une aide fédérale pour les incendies de Los Angeles",
     "es": "El gobernador Newsom anuncia la extensión del plazo para solicitar asistencia federal para los incendios de Los Ángeles",
@@ -134,7 +125,6 @@
 "story_98791_title": {
     "status": "ap_review",
     "comment": "machine_translated",
-    "src_file": "pages/lafires/",
     "en": "Governor Newsom extends protections for LA firestorm survivors",
     "fr": "Le gouverneur Newsom étend les protections pour les survivants des incendies de LA",
     "es": "El gobernador Newsom extiende las protecciones para los sobrevivientes de la tormenta de fuego de LA",
@@ -149,7 +139,6 @@
 "story_98782_title": {
     "status": "ap_review",
     "comment": "machine_translated",
-    "src_file": "pages/lafires/",
     "en": "What they’re saying: Governor Newsom’s state of emergency to fast-track wildfire prevention projects",
     "fr": "Ce qu'ils disent : L'état d'urgence du gouverneur Newsom pour accélérer les projets de prévention des incendies de forêt",
     "es": "Lo que están diciendo: Estado de emergencia del gobernador Newsom para acelerar proyectos de prevención de incendios forestales",
@@ -164,7 +153,6 @@
 "story_98775_title": {
     "status": "ap_review",
     "comment": "machine_translated",
-    "src_file": "pages/lafires/",
     "en": "With rain incoming, California takes action to protect fire-impacted communities in Los Angeles County",
     "fr": "Avec l'arrivée de la pluie, la Californie prend des mesures pour protéger les communautés touchées par les incendies dans le comté de Los Angeles",
     "es": "Con la llegada de la lluvia, California toma medidas para proteger a las comunidades afectadas por incendios en el condado de Los Ángeles",
@@ -179,7 +167,6 @@
 "story_98699_title": {
     "status": "ap_review",
     "comment": "machine_translated",
-    "src_file": "pages/lafires/",
     "en": "Governor Newsom announces statewide plan for economic growth, $245 million for more jobs — with additional investment for LA&#8217;s recovery",
     "fr": "Le gouverneur Newsom annonce un plan à l'échelle de l'État pour la croissance économique, 245 millions de dollars pour plus d'emplois — avec un investissement supplémentaire pour la reprise de LA",
     "es": "El gobernador Newsom anuncia un plan estatal para el crecimiento económico, $245 millones para más empleos — con inversión adicional para la recuperación de LA",

--- a/src/_data/i18n/i18n-track-progress.json
+++ b/src/_data/i18n/i18n-track-progress.json
@@ -1,7 +1,6 @@
 {
   "track_progress_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Track LA’s progress",
     "fr": "Suivre les progrès de LA",
     "es": "Siga el progreso de Los Ángeles",
@@ -14,7 +13,6 @@
   },
   "track_progress_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Stay safe and informed. These trusted sources of info can help.",
     "fr": "Restez en sécurité et informé. Ces sources d'information fiables peuvent vous aider.",
     "es": "Manténgase seguro e informado. Estas fuentes de información confiables pueden ayudar.",
@@ -27,7 +25,6 @@
   },
   "track_progress_lead_text": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Stay safe and informed. These trusted sources of info can help.",
     "fr": "Restez en sécurité et informé. Ces sources d'information fiables peuvent vous aider.",
     "es": "Manténgase seguro e informado. Estas fuentes de información confiables pueden ayudar.",
@@ -41,7 +38,6 @@
   "track_progress_governor_website": {
     "status": "avantpage_review",
     "comment": "links added",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "LA’s recovery is Governor Newsom’s top priority. See all state actions to support recovery and rebuilding on <a href=\"https://www.gov.ca.gov/2025/01/24/heres-all-the-actions-governor-newsom-has-taken-in-response-to-the-los-angeles-fires/\">the Governor’s website</a>.",
     "fr": "La reprise de LA est la priorité absolue du gouverneur Newsom. Consultez toutes les actions de l'État pour soutenir la reprise et la reconstruction sur <a href=\"https://www.gov.ca.gov/2025/01/24/heres-all-the-actions-governor-newsom-has-taken-in-response-to-the-los-angeles-fires/\">le site web du gouverneur</a>.",
     "es": "La recuperación de Los Ángeles es la principal prioridad del gobernador Newsom. Consulte todas las acciones estatales para apoyar la recuperación y la reconstrucción en <a href=\"https://www.gov.ca.gov/2025/01/24/heres-all-the-actions-governor-newsom-has-taken-in-response-to-the-los-angeles-fires/\">el sitio web del gobernador</a>.",
@@ -55,7 +51,6 @@
   },
   "track_progress_people_helped": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "People helped",
     "fr": "Personnes aidées",
     "es": "Personas que recibieron ayuda",
@@ -68,7 +63,6 @@
   },
   "track_progress_local_state_federal_help_at_centers": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Local, state, and federal governments offer in-person help at disaster recovery centers.",
     "fr": "Les gouvernements locaux, étatiques et fédéraux offrent une aide en personne dans les centres de rétablissement après sinistre.",
     "es": "Los centros de recuperación por catástrofes ofrecen ayuda en persona a nivel local, estatal y federal.",
@@ -81,7 +75,6 @@
   },
   "track_progress_at_disaster_recovery_centers": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "At disaster recovery centers",
     "fr": "Dans les centres de rétablissement après sinistre",
     "es": "En centros de recuperación por catástrofes",
@@ -94,7 +87,6 @@
   },
   "track_progress_visits": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "visits",
     "fr": "visites",
     "es": "visitas",
@@ -107,13 +99,11 @@
   },
   "track_progress_reported_by_fema": {
     "status": "ap_not_found_in_ap_delivery",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Reported by Federal Emergency Management Agency",
     "fr": "Rapporté par l'Agence fédérale de gestion des urgences"
   },
   "track_progress_by_fema_assistance": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "By FEMA assistance",
     "fr": "Par l'assistance de la FEMA",
     "es": "Por medio de la ayuda de la Agencia Federal para el Manejo de Emergencias (FEMA)",
@@ -127,7 +117,6 @@
   "track_progress_people_helped_lowercase": {
     "status": "ap_review",
     "comment": "Extracted from submitted translation, converted to lowercase",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "people helped",
     "fr": "personnes aidées",
     "es": "personas que recibieron ayuda",
@@ -140,7 +129,6 @@
   },
   "track_progress_distributed_to_individuals": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "distributed to individuals",
     "fr": "distribué aux individus",
     "es": "distribuidos a individuos",
@@ -154,7 +142,6 @@
   },
   "track_progress_schools_reopened": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Schools reopened",
     "fr": "Écoles rouvertes",
     "es": "Escuelas reabiertas",
@@ -167,7 +154,6 @@
   },
   "track_progress_many_schools_in_fire_areas_damaged": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Many public schools operating in fire affected areas were damaged or destroyed. Federal, state, and local government is coordinating to help schools resume instruction for students.",
     "fr": "De nombreuses écoles publiques opérant dans les zones touchées par les incendies ont été endommagées ou détruites. Les gouvernements fédéral, étatique et local coordonnent leurs efforts pour aider les écoles à reprendre l'enseignement pour les élèves.",
     "es": "Muchas escuelas públicas que operaban en áreas afectadas por el incendio se dañaron o se destruyeron. Los gobiernos federales, estatales y locales se están coordinando para ayudar a las escuelas a reanudar las clases para los estudiantes.",
@@ -180,7 +166,6 @@
   },
   "track_progress_damaged_or_destroyed_public_schools": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Damaged or destroyed public schools",
     "fr": "Écoles publiques endommagées ou détruites",
     "es": "Escuelas públicas dañadas o destruidas",
@@ -194,7 +179,6 @@
   "track_progress_of": {
     "status": "ap_review",
     "comment": "Extracted from submitted translation, check page for usage",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "of",
     "fr": "sur",
     "es": "de",
@@ -209,7 +193,6 @@
   "track_progress_have_resumed_instruction": {
     "status": "ap_review",
     "comment": "Extracted from submitted translation, check page for usage",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "have resumed instruction",
     "fr": "ont repris l'enseignement",
     "es": "reanudaron las clases",
@@ -223,7 +206,6 @@
   },
   "track_progress_teaching_in_person": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Teaching in-person:",
     "fr": "Enseignement en présentiel:",
     "es": "Clases presenciales:",
@@ -237,7 +219,6 @@
   },
   "track_progress_teaching_online": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Teaching online:",
     "fr": "Enseignement en ligne:",
     "es": "Clases en línea:",
@@ -252,7 +233,6 @@
   "track_progress_reported_to_schools_task_force": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Reported to Schools Task Force",
     "fr": "Rapporté au groupe de travail des écoles",
     "es": "Reportado al Grupo de Trabajo de Escuelas",
@@ -266,7 +246,6 @@
   "track_progress_data_as_of": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Data as of <date> at <time>",
     "fr": "Données en date du <date> à <time>",
     "es": "Datos al <date> a las <time>",
@@ -280,7 +259,6 @@
   "track_progress_properties_cleaned_up": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Properties cleaned up",
     "fr": "Propriétés nettoyées",
     "es": "Propiedades limpiadas",
@@ -294,7 +272,6 @@
   "track_progress_there_are_2_phases_of_cleanup": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "There are 2 phases of cleanup:",
     "fr": "Il y a 2 phases de nettoyage:",
     "es": "Hay 2 fases de limpieza:",
@@ -308,7 +285,6 @@
   "track_progress_phase_1": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Phase 1",
     "fr": "Phase 1",
     "es": "Fase 1",
@@ -322,7 +298,6 @@
   "track_progress_epa_clears_household_hazardous_waste": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "U.S. Environmental Protection Agency clears household hazardous waste",
     "fr": "L'Agence de protection environnementale des États-Unis élimine les déchets ménagers dangereux",
     "es": "La Agencia de Protección Ambiental de EE. UU. elimina los residuos peligrosos domésticos",
@@ -336,7 +311,6 @@
   "track_progress_army_corps_clears_structural_debris": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "U.S. Army Corps of Engineers clears structural debris",
     "fr": "Le Corps des ingénieurs de l'armée américaine dégage les débris structurels",
     "es": "El Cuerpo de Ingenieros del Ejército de EE. UU. retira los escombros estructurales",
@@ -350,7 +324,6 @@
   "track_progress_accepting_phase_2_entry_forms": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Currently, LA County is <a href=\"https://recovery.lacounty.gov/debris-removal/roe/#1738023329409-58c2a679-5f63\">accepting Right of Entry forms</a> for Phase 2. Once validated by the county, the U.S. Army Corps of Engineers assesses properties and begins debris removal.",
     "fr": "Actuellement, le comté de LA <a href=\"https://recovery.lacounty.gov/debris-removal/roe/#1738023329409-58c2a679-5f63\">accepte les formulaires de droit d'entrée</a> pour la Phase 2. Une fois validés par le comté, le Corps des ingénieurs de l'armée américaine évalue les propriétés et commence l'enlèvement des débris.",
     "es": "Actualmente, el Condado de LA está <a href=\"https://recovery.lacounty.gov/debris-removal/roe/#1738023329409-58c2a679-5f63\">aceptando formularios de Derecho de Entrada</a> para la Fase 2. Una vez validados por el condado, el Cuerpo de Ingenieros del Ejército de EE. UU. evalúa las propiedades y comienza la remoción de escombros.",
@@ -364,7 +337,6 @@
   "track_progress_hazardous_household_waste_cleanup": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Hazardous household waste cleanup",
     "fr": "Nettoyage des déchets ménagers dangereux",
     "es": "Limpieza de residuos peligrosos domésticos",
@@ -378,7 +350,6 @@
   "track_progress_hazardous_household_waste_cleanup_progress": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Hazardous household waste cleanup progress",
     "fr": "Progrès du nettoyage des déchets ménagers dangereux",
     "es": "Progreso de la limpieza de residuos peligrosos domésticos",
@@ -392,7 +363,6 @@
   "track_progress_phase_1_complete": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Phase 1 complete",
     "fr": "Phase 1 terminée",
     "es": "Fase 1 completada",
@@ -406,7 +376,6 @@
   "track_progress_data_notes": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Data notes",
     "fr": "Notes sur les données",
     "es": "Notas sobre los datos",
@@ -420,7 +389,6 @@
   "track_progress_epa_progress_dashboard": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "For a detailed breakdown of Phase 1 progress, see the <a href=\"https://storymaps.arcgis.com/stories/12e839aa88764185ab7ef3f84cace1ea\">U.S. Environmental Protection Agency’s progress dashboard</a>.",
     "fr": "Pour une analyse détaillée des progrès de la Phase 1, consultez le <a href=\"https://storymaps.arcgis.com/stories/12e839aa88764185ab7ef3f84cace1ea\">tableau de bord des progrès de l'Agence de protection environnementale des États-Unis</a>.",
     "es": "Para un desglose detallado del progreso de la Fase 1, consulte el <a href=\"https://storymaps.arcgis.com/stories/12e839aa88764185ab7ef3f84cace1ea\">panel de progreso de la Agencia de Protección Ambiental de EE. UU.</a>",
@@ -434,7 +402,6 @@
   "track_progress_complete_means_staff_finished_removing_hazardous_waste": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Complete means staff finished removing hazardous waste, found unsafe structural debris that requires Phase 2 cleanup, or could not gain access to the property.",
     "fr": "Terminé signifie que le personnel a fini d'enlever les déchets dangereux, a trouvé des débris structurels dangereux nécessitant un nettoyage de Phase 2, ou n'a pas pu accéder à la propriété.",
     "es": "Completo significa que el personal terminó de retirar los residuos peligrosos, encontró escombros estructurales inseguros que requieren limpieza de Fase 2, o no pudo acceder a la propiedad.",
@@ -448,7 +415,6 @@
   "track_progress_us_army_corps_of_engineers_will_clear_any_unsafe_properties_in_phase_2": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "The U.S. Army Corps of Engineers will clear any unsafe properties in phase 2.",
     "fr": "Le Corps des ingénieurs de l'armée américaine dégagera toutes les propriétés dangereuses dans la phase 2.",
     "es": "El Cuerpo de Ingenieros del Ejército de EE. UU. limpiará cualquier propiedad insegura en la fase 2.",
@@ -462,7 +428,6 @@
   "track_progress_reported_by_epa": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Reported by U.S. Environmental Protection Agency",
     "fr": "Rapporté par l'Agence de protection environnementale des États-Unis",
     "es": "Reportado por la Agencia de Protección Ambiental de EE. UU.",
@@ -476,7 +441,6 @@
   "track_progress_phase_2": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Phase 2",
     "fr": "Phase 2",
     "es": "Fase 2",
@@ -490,7 +454,6 @@
   "track_progress_structural_debris_removal": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Structural debris removal",
     "fr": "Enlèvement des débris structurels",
     "es": "Remoción de escombros estructurales",
@@ -504,7 +467,6 @@
   "track_progress_right_of_entry_forms": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Right of Entry forms",
     "fr": "Formulaires de droit d'entrée",
     "es": "Formularios de Derecho de Entrada",
@@ -518,7 +480,6 @@
   "track_progress_right_of_entry_forms_submitted_to_la_county": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Right of Entry forms submitted to LA County",
     "fr": "Formulaires de droit d'entrée soumis au comté de LA",
     "es": "Formularios de Derecho de Entrada presentados al Condado de LA",
@@ -532,7 +493,6 @@
   "track_progress_opt_in": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Opt-in:",
     "fr": "Participation:",
     "es": "Participar:",
@@ -546,7 +506,6 @@
   "track_progress_opt_out": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Opt-out:",
     "fr": "Non-participation:",
     "es": "No participar:",
@@ -560,7 +519,6 @@
   "track_progress_reported_by_la_county": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Reported by LA County",
     "fr": "Rapporté par le comté de LA",
     "es": "Reportado por el Condado de LA",
@@ -574,7 +532,6 @@
   "track_progress_structural_debris_removal_progress": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Structural debris removal progress",
     "fr": "Progrès de l'enlèvement des débris structurels",
     "es": "Progreso en la remoción de escombros estructurales",
@@ -588,7 +545,6 @@
   "track_progress_parcels_have_been_accepted_for_phase_2_debris_removal": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "parcels have been accepted for Phase 2 debris removal",
     "fr": "parcelles ont été acceptées pour l'enlèvement des débris de Phase 2",
     "es": "parcelas han sido aceptadas para la remoción de escombros de la Fase 2",
@@ -602,7 +558,6 @@
   "track_progress_phase_2_progress": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Phase 2 progress",
     "fr": "Progrès de la Phase 2",
     "es": "Progreso de la Fase 2",
@@ -616,7 +571,6 @@
   "track_progress_parcels_completed_lowercase": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "parcels completed",
     "fr": "parcelles terminées",
     "es": "parcelas completadas",
@@ -630,7 +584,6 @@
   "track_progress_detailed_breakdown_of_phase_2_process_and_current_status": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "For a detailed breakdown of the Phase 2 process and current status, see the <a href=\"https://www.spl.usace.army.mil/Missions/Emergency-Management/Los-Angeles-County-Wildfire-Debris-Removal-Mission/\">U.S. Army Corps of Engineers' progress dashboard</a>.",
     "fr": "Pour une analyse détaillée du processus de Phase 2 et de l'état actuel, consultez le <a href=\"https://www.spl.usace.army.mil/Missions/Emergency-Management/Los-Angeles-County-Wildfire-Debris-Removal-Mission/\">tableau de bord des progrès du Corps des ingénieurs de l'armée américaine</a>.",
     "es": "Para un desglose detallado del proceso de la Fase 2 y el estado actual, consulte el <a href=\"https://www.spl.usace.army.mil/Missions/Emergency-Management/Los-Angeles-County-Wildfire-Debris-Removal-Mission/\">panel de progreso del Cuerpo de Ingenieros del Ejército de EE. UU.</a>",
@@ -644,7 +597,6 @@
   "track_progress_property_owners_must_submit_opt_in_right_of_entry_forms": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Property owners must submit opt-in Right of Entry forms for the U.S. Army Corps of Engineers to complete Phase 2. Property owners that opt out of this process must cover debris removal expenses and work.",
     "fr": "Les propriétaires doivent soumettre des formulaires de droit d'entrée avec participation pour que le Corps des ingénieurs de l'armée américaine puisse compléter la Phase 2. Les propriétaires qui ne participent pas à ce processus doivent couvrir les dépenses et le travail d'enlèvement des débris.",
     "es": "Los propietarios deben presentar formularios de Derecho de Entrada para participar y que el Cuerpo de Ingenieros del Ejército de EE. UU. complete la Fase 2. Los propietarios que opten por no participar en este proceso deben cubrir los gastos y el trabajo de remoción de escombros.",
@@ -658,7 +610,6 @@
   "track_progress_progress_bar_measures_the_number_of_parcels_that_have_completed_phase_2": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "The progress bar measures the number of parcels that have completed Phase 2 against the estimated total number of eligible parcels.",
     "fr": "La barre de progression mesure le nombre de parcelles qui ont terminé la Phase 2 par rapport au nombre total estimé de parcelles éligibles.",
     "es": "La barra de progreso mide el número de parcelas que han completado la Fase 2 en comparación con el número total estimado de parcelas elegibles.",
@@ -672,7 +623,6 @@
   "track_progress_complete_means_structural_debris_has_been_removed_from_the_property": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Complete means that structural debris has been removed from the property and the parcel has been returned back to the owner.",
     "fr": "Terminé signifie que les débris structurels ont été enlevés de la propriété et que la parcelle a été rendue au propriétaire.",
     "es": "Completo significa que los escombros estructurales han sido retirados de la propiedad y la parcela ha sido devuelta al propietario.",
@@ -686,7 +636,6 @@
   "track_progress_reported_by_us_army_corps_of_engineers": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Reported by U.S. Army Corps of Engineers",
     "fr": "Rapporté par le Corps des ingénieurs de l'armée américaine",
     "es": "Reportado por el Cuerpo de Ingenieros del Ejército de EE. UU.",
@@ -700,7 +649,6 @@
   "track_progress_water_restored": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Water restored",
     "fr": "Eau rétablie",
     "es": "Agua restaurada",
@@ -714,7 +662,6 @@
   "track_progress_california_state_water_resources_control_board": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "The California State Water Resources Control Board is working with local water systems impacted by the fires to restore safe drinking water for residents.",
     "fr": "Le Conseil de contrôle des ressources en eau de l'État de Californie travaille avec les systèmes d'eau locaux touchés par les incendies pour rétablir l'eau potable sûre pour les résidents.",
     "es": "La Junta Estatal de Control de Recursos Hídricos de California está trabajando con los sistemas de agua locales afectados por los incendios para restaurar el agua potable segura para los residentes.",
@@ -728,7 +675,6 @@
   "track_progress_water_systems_status": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Water systems status",
     "fr": "État des systèmes d'eau",
     "es": "Estado de los sistemas de agua",
@@ -742,7 +688,6 @@
   "track_progress_systems_safe_to_drink": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "systems safe to drink",
     "fr": "systèmes sûrs pour la consommation",
     "es": "sistemas seguros para beber",
@@ -756,7 +701,6 @@
   "track_progress_systems_in_progress": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "systems in progress",
     "fr": "systèmes en cours",
     "es": "sistemas en progreso",
@@ -770,7 +714,6 @@
   "track_progress_reported_by_state_water_resources_control_board": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Reported by State Water Resources Control Board",
     "fr": "Rapporté par le Conseil de contrôle des ressources en eau de l'État",
     "es": "Reportado por la Junta Estatal de Control de Recursos Hídricos",
@@ -784,7 +727,6 @@
   "track_progress_air_quality": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Air quality",
     "fr": "Qualité de l'air",
     "es": "Calidad del aire",
@@ -798,7 +740,6 @@
   "track_progress_south_coast_air_quality_management_district": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "South Coast Air Quality Management District and the California Air Resources Board are working together to measure air quality in your area.",
     "fr": "Le District de gestion de la qualité de l'air de la côte sud et le Conseil des ressources en air de Californie travaillent ensemble pour mesurer la qualité de l'air dans votre région.",
     "es": "El Distrito de Gestión de la Calidad del Aire de la Costa Sur y la Junta de Recursos del Aire de California están trabajando juntos para medir la calidad del aire en su área.",
@@ -812,7 +753,6 @@
   "track_progress_monitoring_occurs_in_two_stages": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Monitoring occurs in two stages: mobile monitoring surveys and stationary monitoring.",
     "fr": "La surveillance se fait en deux étapes : enquêtes de surveillance mobile et surveillance fixe.",
     "es": "El monitoreo ocurre en dos etapas: encuestas de monitoreo móvil y monitoreo estacionario.",
@@ -826,7 +766,6 @@
   "track_progress_stage_1_mobile_monitoring_surveys": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Stage 1 - Mobile monitoring surveys:",
     "fr": "Étape 1 - Enquêtes de surveillance mobile:",
     "es": "Etapa 1 - Encuestas de monitoreo móvil:",
@@ -840,7 +779,6 @@
   "track_progress_four_mobile_surveys_were_completed": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Four mobile surveys were completed, two for the Eaton fire area and two for the Palisades fire area. Mobile surveys capture a snapshot in time of air toxic metals and volatile organic compounds (VOCs). The data was used to help guide locations for stationary air monitors.",
     "fr": "Quatre enquêtes mobiles ont été réalisées, deux pour la zone de l'incendie d'Eaton et deux pour la zone de l'incendie des Palisades. Les enquêtes mobiles capturent un instantané des métaux toxiques dans l'air et des composés organiques volatils (COV). Les données ont été utilisées pour aider à guider l'emplacement des moniteurs d'air fixes.",
     "es": "Se completaron cuatro encuestas móviles, dos para el área del incendio de Eaton y dos para el área del incendio de Palisades. Las encuestas móviles capturan una instantánea en el tiempo de metales tóxicos en el aire y compuestos orgánicos volátiles (COV). Los datos se utilizaron para ayudar a guiar las ubicaciones de los monitores de aire estacionarios.",
@@ -854,7 +792,6 @@
   "track_progress_they_are_not_used_to_establish_health_risks": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "They are not used to establish health risks.",
     "fr": "Elles ne sont pas utilisées pour établir les risques pour la santé.",
     "es": "No se utilizan para establecer riesgos para la salud.",
@@ -868,7 +805,6 @@
   "track_progress_stage_2_stationary_air_quality_monitors": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Stage 2 - Stationary air quality monitors:",
     "fr": "Étape 2 - Moniteurs fixes de la qualité de l'air:",
     "es": "Etapa 2 - Monitores estacionarios de calidad del aire:",
@@ -882,7 +818,6 @@
   "track_progress_they_measure_pollutants_in_the_air": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "They measure pollutants in the air. This includes particulates (PM2.5 and PM10), lead, arsenic, other toxic metals, and asbestos.",
     "fr": "Ils mesurent les polluants dans l'air. Cela inclut les particules (PM2.5 et PM10), le plomb, l'arsenic, d'autres métaux toxiques et l'amiante.",
     "es": "Miden los contaminantes en el aire. Esto incluye partículas (PM2.5 y PM10), plomo, arsénico, otros metales tóxicos y asbesto.",
@@ -896,7 +831,6 @@
   "track_progress_eaton_fire_area": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Eaton fire area",
     "fr": "Zone de l'incendie d'Eaton",
     "es": "Área del incendio de Eaton",
@@ -910,7 +844,6 @@
   "track_progress_results_show": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Results show",
     "fr": "Les résultats montrent",
     "es": "Los resultados muestran",
@@ -924,7 +857,6 @@
   "track_progress_eaton_results_1": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Some elevated levels of Total Chromium, Nickel, Lead, and Arsenic",
     "fr": "Des niveaux élevés de Chrome total, Nickel, Plomb et Arsenic",
     "es": "Algunos niveles elevados de Cromo Total, Níquel, Plomo y Arsénico",
@@ -938,7 +870,6 @@
   "track_progress_eaton_results_2": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "No elevated levels of VOCs including benzene",
     "fr": "Pas de niveaux élevés de VOC, y compris le benzène",
     "es": "Sin niveles elevados de VOC, incluido el benceno",
@@ -952,7 +883,6 @@
   "track_progress_eaton_results_summary": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Overall, the majority of results were within background levels.",
     "fr": "Dans l'ensemble, la majorité des résultats étaient dans les niveaux de fond.",
     "es": "En general, la mayoría de los resultados estaban dentro de los niveles de fondo.",
@@ -966,7 +896,6 @@
   "track_progress_reported_by_south_coast_air_quality_management_district": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Reported by South Coast Air Quality Management District",
     "fr": "Rapporté par le District de gestion de la qualité de l'air de la côte sud",
     "es": "Reportado por el Distrito de Gestión de la Calidad del Aire de la Costa Sur",
@@ -980,7 +909,6 @@
   "track_progress_palisades_fire_area": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Palisades fire area",
     "fr": "Zone de l'incendie des Palisades",
     "es": "Área del incendio de Palisades",
@@ -994,7 +922,6 @@
   "track_progress_mobile_air_monitoring": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Mobile air monitoring",
     "fr": "Surveillance mobile de l'air",
     "es": "Monitoreo móvil del aire",
@@ -1008,7 +935,6 @@
   "track_progress_mobile_air_monitoring_is_now_complete": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Mobile air monitoring is now complete.",
     "fr": "La surveillance mobile de l'air est maintenant terminée.",
     "es": "El monitoreo móvil del aire está ahora completo.",
@@ -1022,7 +948,6 @@
   "track_progress_four_mobile_surveys_two_in_each_burn_area_were_conducted": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Four mobile surveys, two in each burn area, were conducted.",
     "fr": "Quatre enquêtes mobiles, deux dans chaque zone brûlée, ont été réalisées.",
     "es": "Se realizaron cuatro encuestas móviles, dos en cada área quemada.",
@@ -1036,7 +961,6 @@
   "track_progress_overall_survey_results_from_eaton_and_palisades_areas_were_within_background_levels": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Overall, survey results from Eaton and Palisades areas were within background levels, with some elevated levels of lead, arsenic, chromium and nickel.",
     "fr": "Dans l'ensemble, les résultats des enquêtes des zones d'Eaton et des Palisades étaient dans les niveaux de fond, avec quelques niveaux élevés de plomb, d'arsenic, de chrome et de nickel.",
     "es": "En general, los resultados de las encuestas de las áreas de Eaton y Palisades estaban dentro de los niveles de fondo, con algunos niveles elevados de plomo, arsénico, cromo y níquel.",
@@ -1050,7 +974,6 @@
   "track_progress_stationary_air_monitoring": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Stationary air monitoring",
     "fr": "Surveillance de l'air fixe",
     "es": "Monitoreo estacionario del aire",
@@ -1064,7 +987,6 @@
   "track_progress_mobile_monitoring_survey_1_completed_on_february_10_2025": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Mobile monitoring survey #1 was completed on February 10, 2025.",
     "fr": "L'enquête de surveillance mobile n°1 a été achevée le 10 février 2025.",
     "es": "La encuesta de monitoreo móvil n.° 1 se completó el 10 de febrero de 2025.",
@@ -1078,7 +1000,6 @@
   "track_progress_overall_results_show_no_elevated_levels_of": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Overall, results show <strong>no elevated</strong> levels of",
     "fr": "Dans l'ensemble, les résultats ne montrent <strong>pas de niveaux élevés</strong> de",
     "es": "En general, los resultados no muestran niveles <strong>elevados</strong> de",
@@ -1092,7 +1013,6 @@
   "track_progress_air_toxic_metals_including_lead_and_arsenic": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Air toxic metals including lead and arsenic",
     "fr": "Métaux toxiques dans l'air, y compris le plomb et l'arsenic",
     "es": "Metales tóxicos en el aire, incluidos el plomo y el arsénico",
@@ -1106,7 +1026,6 @@
   "track_progress_volatile_organic_compounds_including_benzene": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Volatile Organic Compounds including benzene",
     "fr": "Composés organiques volatils, y compris le benzène",
     "es": "Compuestos orgánicos volátiles, incluido el benceno",
@@ -1120,7 +1039,6 @@
   "track_progress_elevated_methane_detected": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "One elevated level of methane, possibly from a gas leak, was detected. This result was reported to utilities and public health agencies for further investigation.",
     "fr": "Un niveau élevé de méthane, possiblement dû à une fuite de gaz, a été détecté. Ce résultat a été signalé aux services publics et aux agences de santé publique pour une enquête plus approfondie.",
     "es": "Se detectó un nivel elevado de metano, posiblemente debido a una fuga de gas. Este resultado se informó a los servicios públicos y las agencias de salud pública para una investigación más detallada.",
@@ -1134,7 +1052,6 @@
   "track_progress_how_we_are_monitoring": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "How we are monitoring",
     "fr": "Comment nous surveillons",
     "es": "Cómo estamos monitoreando",
@@ -1148,7 +1065,6 @@
   "track_progress_mobile_monitoring_surveys_completed_in_eaton_and_palisades_areas": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "mobile monitoring surveys completed in Eaton and Palisades areas",
     "fr": "enquêtes de surveillance mobile terminées dans les zones d'Eaton et des Palisades",
     "es": "encuestas de monitoreo móvil completadas en las áreas de Eaton y Palisades",
@@ -1162,7 +1078,6 @@
   "track_progress_stationary_air_quality_monitoring_sites_deployed": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "stationary air quality monitoring sites deployed for Eaton and Palisades areas",
     "fr": "sites fixes de surveillance de la qualité de l'air déployés pour les zones d'Eaton et des Palisades",
     "es": "sitios de monitoreo estacionario de la calidad del aire desplegados para las áreas de Eaton y Palisades",
@@ -1176,7 +1091,6 @@
   "track_progress_eaton_data_results": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Eaton data results",
     "fr": "Résultats des données d'Eaton",
     "es": "Resultados de datos de Eaton",
@@ -1190,7 +1104,6 @@
   "track_progress_altadena_golf_course_results_1": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "While some samples are still being analyzed, analysis continues to show levels do not pose an immediate risk to public health. Residents are encouraged to continue following the safety precautions outlined by the Los Angeles County Department of Public Health.",
     "fr": "Bien que certains échantillons soient encore en cours d'analyse, l'analyse continue de montrer que les niveaux ne présentent pas de risque immédiat pour la santé publique. Les résidents sont encouragés à continuer de suivre les précautions de sécurité décrites par le Département de la Santé Publique du Comté de Los Angeles.",
     "es": "Aunque algunas muestras todavía están siendo analizadas, el análisis continúa mostrando que los niveles no representan un riesgo inmediato para la salud pública. Se anima a los residentes a seguir las precauciones de seguridad descritas por el Departamento de Salud Pública del Condado de Los Ángeles.",
@@ -1204,7 +1117,6 @@
   "track_progress_altadena_golf_course_results_2": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Samples from 3/2/25, 3/5/25, and 3/8/25 near Altadena Golf Course and at Christ the Shepherd Lutheran Church and Fire Station 11:",
     "fr": "Échantillons du 2/3/25, 5/3/25 et 8/3/25 près du terrain de golf d'Altadena et à l'église luthérienne Christ the Shepherd et à la caserne de pompiers 11 :",
     "es": "Muestras del 2/3/25, 5/3/25 y 8/3/25 cerca del campo de golf de Altadena y en la Iglesia Luterana Christ the Shepherd y la Estación de Bomberos 11:",
@@ -1218,7 +1130,6 @@
   "track_progress_eaton_data_list_1": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "All air toxic metals are within background levels. Asbestos was detected near the Altadena Golf Course and Christ the Shepherd Lutheran Church on 3/5/25, but then was not detected on 3/8/25.",
     "fr": "Tous les métaux toxiques dans l'air sont dans les limites des niveaux de fond. De l'amiante a été détectée près du terrain de golf d'Altadena et de l'église luthérienne Christ the Shepherd le 5/3/25, mais n'a pas été détectée le 8/3/25.",
     "es": "Todos los metales tóxicos del aire están dentro de los niveles de fondo. Se detectó asbesto cerca del campo de golf de Altadena y la Iglesia Luterana Christ the Shepherd el 5/3/25, pero luego no se detectó el 8/3/25.",
@@ -1232,7 +1143,6 @@
   "track_progress_eaton_data_list_2": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "To date, continuous PM10 and PM2.5 hourly data were below federal standards.",
     "fr": "À ce jour, les données horaires continues de PM10 et PM2,5 étaient inférieures aux normes fédérales.",
     "es": "Hasta la fecha, los datos horarios continuos de PM10 y PM2.5 estaban por debajo de los estándares federales.",
@@ -1246,7 +1156,6 @@
   "track_progress_palisades_data_results": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Palisades data results",
     "fr": "Résultats des données des Palisades",
     "es": "Resultados de datos de Palisades",
@@ -1260,7 +1169,6 @@
   "track_progress_will_rogers_results_1": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "While some samples are still being analyzed, analysis continues to show levels do not pose an immediate risk to public health. Residents are encouraged to continue following the safety precautions outlined by the Los Angeles County Department of Public Health. ",
     "fr": "Bien que certains échantillons soient encore en cours d'analyse, l'analyse continue de montrer que les niveaux ne présentent pas de risque immédiat pour la santé publique. Les résidents sont encouragés à continuer de suivre les précautions de sécurité décrites par le Département de la Santé Publique du Comté de Los Angeles.",
     "es": "Aunque algunas muestras todavía están siendo analizadas, el análisis continúa mostrando que los niveles no representan un riesgo inmediato para la salud pública. Se anima a los residentes a seguir las precauciones de seguridad descritas por el Departamento de Salud Pública del Condado de Los Ángeles.",
@@ -1274,7 +1182,6 @@
   "track_progress_will_rogers_results_2": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Samples from 3/2/25, 3/5/25, and 3/8/25 near Will Rogers State Beach and at Fire Station 69:",
     "fr": "Échantillons du 2/3/25, 5/3/25 et 8/3/25 près de la plage d'État Will Rogers et à la caserne de pompiers 69 :",
     "es": "Muestras del 2/3/25, 5/3/25 y 8/3/25 cerca de la playa estatal Will Rogers y en la Estación de Bomberos 69:",
@@ -1288,7 +1195,6 @@
   "track_progress_pasisades_data_list_1": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "Some air toxic metals were above background levels, but do not pose an immediate health risk. Asbestos was not detected.",
     "fr": "Certains métaux toxiques dans l'air étaient au-dessus des niveaux de fond, mais ne présentent pas de risque immédiat pour la santé. L'amiante n'a pas été détectée.",
     "es": "Algunos metales tóxicos del aire estaban por encima de los niveles de fondo, pero no representan un riesgo inmediato para la salud. No se detectó asbesto.",
@@ -1302,7 +1208,6 @@
   "track_progress_pasisades_data_list_2": {
     "status": "ap_review",
     "comment": "machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "To date, continuous PM10 and PM2.5 hourly data were below federal standards.",
     "fr": "À ce jour, les données horaires continues de PM10 et PM2,5 étaient inférieures aux normes fédérales.",
     "es": "Hasta la fecha, los datos horarios continuos de PM10 y PM2.5 estaban por debajo de los estándares federales.",
@@ -1316,7 +1221,6 @@
   "track_progress_all_results_from_the_stationary_sites_are_available": {
     "status": "ap_review",
     "comment": "Machine translated",
-    "src_file": "pages/lafires/track-progress-shared.html",
     "en": "All results from the stationary sites are available at South Coast Air Quality Management District’s <a href=\"https://www.aqmd.gov/2025-wildfire-response\">2025 Wildfire Response page</a>.",
     "fr": "Tous les résultats des sites fixes sont disponibles sur la <a href=\"https://www.aqmd.gov/2025-wildfire-response\">page de réponse aux feux de forêt 2025</a> du District de gestion de la qualité de l'air de la côte sud.",
     "es": "Todos los resultados de los sitios estacionarios están disponibles en la <a href=\"https://www.aqmd.gov/2025-wildfire-response\">página de Respuesta a Incendios Forestales 2025</a> del Distrito de Gestión de la Calidad del Aire de la Costa Sur.",

--- a/src/_data/i18n/i18n-vital-records.json
+++ b/src/_data/i18n/i18n-vital-records.json
@@ -1,7 +1,6 @@
 {
   "vital_records_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "Vital records",
     "fr": "Certificats de naissance, mariage et décès",
     "es": "Documentos del registro civil",
@@ -14,7 +13,6 @@
   },
   "vital_records_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "How to replace birth, death, and marriage certificates lost in the 2025 LA fires.",
     "fr": "Comment remplacer les certificats de naissance, de décès et de mariage perdus dans les incendies de Los Angeles en 2025.",
     "es": "Cómo reemplazar los certificados de nacimiento, defunción y matrimonio perdidos en los incendios de Los Ángeles de 2025.",
@@ -27,7 +25,6 @@
   },
   "vital_records_description_page": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "Here’s how to replace birth, death, or marriage certificates lost in the fires.",
     "fr": "Voici comment remplacer les certificats de naissance, de décès ou de mariage perdus dans les incendies.",
     "es": "Cómo reemplazar los certificados de nacimiento, defunción o matrimonio perdidos en los incendios.",
@@ -40,7 +37,6 @@
   },
   "vital_records_keywords": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "California, government, LA, Los Angeles, fires, wildfires",
     "fr": "Californie, gouvernement, LA, Los Angeles, incendies, feux de forêt",
     "es": "California, gobierno, LA, Los Ángeles, incendios, incendios forestales",
@@ -53,7 +49,6 @@
   },
   "vital_records_records_from_other_states": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "Records from other states",
     "fr": "Documents d'autres États",
     "es": "Registros de otros estados",
@@ -66,7 +61,6 @@
   },
   "vital_records_contact_county_recorder": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "Contact the county recorder in the county where the birth, marriage, or death happened. See <a href=\"https://www.cdc.gov/nchs/w2w/index.htm\">Where to Write for Vital Records</a>.",
     "fr": "Contactez le bureau d'état civil du comté où la naissance, le mariage ou le décès a eu lieu. Voir <a href=\"https://www.cdc.gov/nchs/w2w/index.htm\">Où écrire pour les actes d'état civil</a>.",
     "es": "Comuníquese con el registrador del condado donde ocurrió el nacimiento, el matrimonio o la muerte. Vea <a href=\"https://www.cdc.gov/nchs/w2w/index.htm\">dónde escribir para obtener documentos del registro civil.</a>",
@@ -80,7 +74,6 @@
   },
   "vital_records_records_from_california": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "Records from California",
     "fr": "Documents de Californie",
     "es": "Registros de California",
@@ -93,7 +86,6 @@
   },
   "vital_records_apply_online": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "To apply online",
     "fr": "Pour appliquer en ligne",
     "es": "Enviar la solicitud en línea",
@@ -106,7 +98,6 @@
   },
   "vital_records_replace_certificates": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "Use these forms to replace certificates issued in California.",
     "fr": "Utilisez ces formulaires pour remplacer les certificats émis en Californie.",
     "es": "Use estos formularios para reemplazar los certificados emitidos en California.",
@@ -119,7 +110,6 @@
   },
   "vital_records_replacements_free": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "Replacements are free for records lost in the fires.",
     "fr": "Les remplacements sont gratuits pour les certificats perdus dans les incendies.",
     "es": "Los reemplazos son gratuitos para los registros perdidos en los incendios.",
@@ -132,7 +122,6 @@
   },
   "vital_records_click_link": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "Click the link to the record you need to start an application (birth, marriage, or death).",
     "fr": "Cliquez sur le lien vers le certificat que vous avez besoin pour commencer une demande (naissance, mariage ou décès).",
     "es": "Haga clic en el enlace del registro que necesita para iniciar una solicitud (nacimiento, matrimonio o muerte).",
@@ -145,7 +134,6 @@
   },
   "vital_records_fill_out_online": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "You can fill it out online and save your work.",
     "fr": "Vous pouvez le remplir en ligne et enregistrer votre travail.",
     "es": "Puede completarlo en línea y guardar su progreso.",
@@ -158,7 +146,6 @@
   },
   "vital_records_upload_documentation": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "If applying for someone else, be ready to upload documentation proving your relationship.",
     "fr": "Si vous postulez pour quelqu'un d'autre, préparez-vous à télécharger la documentation prouvant votre relation.",
     "es": "Si solicita los documentos de otra persona, esté listo para cargar la documentación que demuestre su relación.",
@@ -171,7 +158,6 @@
   },
   "vital_records_sworn_statement": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "Sign and upload a sworn statement with your application.",
     "fr": "Signez et téléchargez un serment avec votre demande.",
     "es": "Firme y cargue una declaración de privacidad con su solicitud.",
@@ -184,7 +170,6 @@
   },
   "vital_records_print_sign": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "Click <span class=\"bold\">Print & Sign</span> to print the application. Take it to a notary public.",
     "fr": "Cliquez sur <span class=\"bold\">Imprimer et signer</span> pour imprimer le formulaire. Prenez-le à un notaire.",
     "es": "Haga clic en <span class=\"bold\">Imprimir y firmar</span> para imprimir la solicitud. Llévela a un notario público.",
@@ -198,7 +183,6 @@
   },
   "vital_records_notary_presence": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "In the notary’s presence, physically sign it. They will then notarize it.",
     "fr": "Dans la présence du notaire, signez-le physiquement. Ils le notarieront alors.",
     "es": "En presencia del notario, escriba su firma. Luego será notarizada.",
@@ -211,7 +195,6 @@
   },
   "vital_records_scan_photo": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "Scan or take a photo of the notarized application, then return and click <span class=\"bold\">Print & Sign</span>.",
     "fr": "Scannez ou prenez une photo de l'application notariée, puis retournez et cliquez sur <span class=\"bold\">Imprimer et signer</span>.",
     "es": "Escanee o tome una fotografía de la solicitud notariada, luego regrese y haga clic en <span class=\"bold\">Imprimir y firmar</span>.",
@@ -225,7 +208,6 @@
   },
   "vital_records_more_than_one_record": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "You can use one notarized statement to apply for more than one record at the same time.",
     "fr": "Vous pouvez utiliser un serment notarié pour postuler pour plusieurs certificats en même temps.",
     "es": "Puede usar un estado de cuenta notariado para solicitar más de un registro al mismo tiempo.",
@@ -238,7 +220,6 @@
   },
   "vital_records_upload_submit": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "Follow the instructions to upload and submit your application.",
     "fr": "Suivez les instructions pour télécharger et soumettre votre demande.",
     "es": "Siga las instrucciones para cargar y enviar su solicitud.",
@@ -251,7 +232,6 @@
   },
   "vital_records_fax_option": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "You also have the option to submit it by fax.",
     "fr": "Vous avez également la possibilité de le soumettre par fax.",
     "es": "También tiene la opción de enviarla por fax.",
@@ -264,7 +244,6 @@
   },
   "vital_records_online_forms": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "Online forms",
     "fr": "Formulaires en ligne",
     "es": "Formularios en línea",
@@ -277,7 +256,6 @@
   },
   "vital_records_birth": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "Birth",
     "fr": "Naissance",
     "es": "Nacimiento",
@@ -290,7 +268,6 @@
   },
   "vital_records_birth_record_english": {
     "status": "avantpage_delivery", 
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "<a href=\"https://powerforms.docusign.net/84a5be6e-d309-4d4e-81d8-82548bfeb3ac?env=na2&acct=4d7f4c21-7650-4313-8c42-292a416eb41a&accountId=4d7f4c21-7650-4313-8c42-292a416eb41a\" class=\"bold\">Birth record</a> (English)",
     "fr": "<a href=\"https://powerforms.docusign.net/84a5be6e-d309-4d4e-81d8-82548bfeb3ac?env=na2&acct=4d7f4c21-7650-4313-8c42-292a416eb41a&accountId=4d7f4c21-7650-4313-8c42-292a416eb41a\" class=\"bold\">Certificat de naissance</a> (Anglais)",
     "es": "<a href=\"https://powerforms.docusign.net/84a5be6e-d309-4d4e-81d8-82548bfeb3ac?env=na2&acct=4d7f4c21-7650-4313-8c42-292a416eb41a&accountId=4d7f4c21-7650-4313-8c42-292a416eb41a\" class=\"bold\">Birth record</a> (English)",
@@ -304,7 +281,6 @@
   },
   "vital_records_birth_record_spanish": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html", 
     "en": "<a href=\"https://powerforms.docusign.net/2e5a9f07-70c0-43c5-b32d-4f338aaed20b?env=na2&acct=4d7f4c21-7650-4313-8c42-292a416eb41a&accountId=4d7f4c21-7650-4313-8c42-292a416eb41a&recipientLang=es_MX\" class=\"bold\">Registros de nacimiento</a> (Español)",
     "fr": "<a href=\"https://powerforms.docusign.net/2e5a9f07-70c0-43c5-b32d-4f338aaed20b?env=na2&acct=4d7f4c21-7650-4313-8c42-292a416eb41a&accountId=4d7f4c21-7650-4313-8c42-292a416eb41a&recipientLang=es_MX\" class=\"bold\">Certificat de naissance</a> (Espagnol)",
     "es": "<a href=\"https://powerforms.docusign.net/2e5a9f07-70c0-43c5-b32d-4f338aaed20b?env=na2&acct=4d7f4c21-7650-4313-8c42-292a416eb41a&accountId=4d7f4c21-7650-4313-8c42-292a416eb41a&recipientLang=es_MX\" class=\"bold\">Registros de nacimiento</a> (español)",
@@ -318,7 +294,6 @@
   },
   "vital_records_marriage": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "Marriage",
     "fr": "Mariage",
     "es": "Matrimonio",
@@ -331,7 +306,6 @@
   },
   "vital_records_marriage_record_english": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "<a href=\"https://powerforms.docusign.net/b2ee3fed-7754-4d1d-b79d-62ccbbac9724?env=na2&acct=4d7f4c21-7650-4313-8c42-292a416eb41a&accountId=4d7f4c21-7650-4313-8c42-292a416eb41a\" class=\"bold\">Marriage record</a> (English)",
     "fr": "<a href=\"https://powerforms.docusign.net/b2ee3fed-7754-4d1d-b79d-62ccbbac9724?env=na2&acct=4d7f4c21-7650-4313-8c42-292a416eb41a&accountId=4d7f4c21-7650-4313-8c42-292a416eb41a\" class=\"bold\">Certificat de mariage</a> (Anglais)",
     "es": "<a href=\"https://powerforms.docusign.net/b2ee3fed-7754-4d1d-b79d-62ccbbac9724?env=na2&acct=4d7f4c21-7650-4313-8c42-292a416eb41a&accountId=4d7f4c21-7650-4313-8c42-292a416eb41a\" class=\"bold\">Marriage record</a> (English)",
@@ -345,7 +319,6 @@
   },
   "vital_records_marriage_record_spanish": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "<a href=\"https://powerforms.docusign.net/4eaeec72-454d-42a5-9fa8-b39667fb3324?env=na2&acct=4d7f4c21-7650-4313-8c42-292a416eb41a&accountId=4d7f4c21-7650-4313-8c42-292a416eb41a&recipientLang=es_MX\" class=\"bold\">Registros de matrimonio</a> (Español)",
     "fr": "<a href=\"https://powerforms.docusign.net/4eaeec72-454d-42a5-9fa8-b39667fb3324?env=na2&acct=4d7f4c21-7650-4313-8c42-292a416eb41a&accountId=4d7f4c21-7650-4313-8c42-292a416eb41a&recipientLang=es_MX\" class=\"bold\">Certificat de mariage</a> (Espagnol)",
     "es": "<a href=\"https://powerforms.docusign.net/4eaeec72-454d-42a5-9fa8-b39667fb3324?env=na2&acct=4d7f4c21-7650-4313-8c42-292a416eb41a&accountId=4d7f4c21-7650-4313-8c42-292a416eb41a&recipientLang=es_MX\" class=\"bold\">Registro de matrimonio</a> (español)",
@@ -359,7 +332,6 @@
   },
   "vital_records_death": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "Death",
     "fr": "Décès",
     "es": "Muerte",
@@ -372,7 +344,6 @@
   },
   "vital_records_death_record_english": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "<a href=\"https://powerforms.docusign.net/5f055c18-61e5-473a-a527-3e6aad8bfe8c?env=na2&acct=4d7f4c21-7650-4313-8c42-292a416eb41a&accountId=4d7f4c21-7650-4313-8c42-292a416eb41a\" class=\"bold\">Death record</a> (English)",
     "fr": "<a href=\"https://powerforms.docusign.net/5f055c18-61e5-473a-a527-3e6aad8bfe8c?env=na2&acct=4d7f4c21-7650-4313-8c42-292a416eb41a&accountId=4d7f4c21-7650-4313-8c42-292a416eb41a\" class=\"bold\">Certificat de décès</a> (Anglais)",
     "es": "<a href=\"https://powerforms.docusign.net/5f055c18-61e5-473a-a527-3e6aad8bfe8c?env=na2&acct=4d7f4c21-7650-4313-8c42-292a416eb41a&accountId=4d7f4c21-7650-4313-8c42-292a416eb41a\" class=\"bold\">Death record</a> (English)",
@@ -386,7 +357,6 @@
   },
   "vital_records_death_record_spanish": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "<a href=\"https://powerforms.docusign.net/8b192521-acb4-4826-a2f1-76735e8b6f86?env=na2&acct=4d7f4c21-7650-4313-8c42-292a416eb41a&accountId=4d7f4c21-7650-4313-8c42-292a416eb41a&recipientLang=es_MX\" class=\"bold\">Registros de defunción</a> (Español)",
     "fr": "<a href=\"https://powerforms.docusign.net/8b192521-acb4-4826-a2f1-76735e8b6f86?env=na2&acct=4d7f4c21-7650-4313-8c42-292a416eb41a&accountId=4d7f4c21-7650-4313-8c42-292a416eb41a&recipientLang=es_MX\" class=\"bold\">Certificat de décès</a> (Espagnol)",
     "es": "<a href=\"https://powerforms.docusign.net/8b192521-acb4-4826-a2f1-76735e8b6f86?env=na2&acct=4d7f4c21-7650-4313-8c42-292a416eb41a&accountId=4d7f4c21-7650-4313-8c42-292a416eb41a&recipientLang=es_MX\" class=\"bold\">Registro de muerte</a> (español)",
@@ -400,7 +370,6 @@
   },
   "vital_records_apply_in_person": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "To apply in person",
     "fr": "Pour postuler en personne",
     "es": "Hacer la solicitud en persona",
@@ -413,7 +382,6 @@
   },
   "vital_records_visit": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "Visit:",
     "fr": "Visiter:",
     "es": "Visite:",
@@ -427,7 +395,6 @@
   },
   "vital_records_disaster_recovery_center": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "A <a href=\"/lafires/get-help-in-person/#Find-the-nearest-Disaster-Recovery-Center\">Disaster Recovery Center</a>, or",
     "fr": "Un <a href=\"/lafires/fr/get-help-in-person/#Find-the-nearest-Disaster-Recovery-Center\">Centre de récupération des dommages</a>, ou",
     "es": "un <a href=\"/lafires/es/get-help-in-person/#Find-the-nearest-Disaster-Recovery-Center\">centro de recuperación por catástrofes</a>, o",
@@ -441,7 +408,6 @@
   },
   "vital_records_county_recorder": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "The county recorder’s office in the county where the birth, marriage, or death occurred.",
     "fr": "Le bureau du recenseur du comté où la naissance, le mariage ou le décès a eu lieu.",
     "es": "comuníquese con el registrador del condado donde ocurrió el nacimiento, el matrimonio o la muerte.",
@@ -454,7 +420,6 @@
   },
   "vital_records_apply_by_mail": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "To apply by mail",
     "fr": "Pour postuler par courrier",
     "es": "Hacer la solicitud por correo postal",
@@ -467,7 +432,6 @@
   },
   "vital_records_print_application": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "Print the application for the record you need.",
     "fr": "Imprimez le formulaire pour le certificat que vous avez besoin.",
     "es": "Imprima la solicitud para el registro que necesite.",
@@ -480,7 +444,6 @@
   },
   "vital_records_pdf_versions": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "PDF versions are available from the <a href=\"https://www.cdph.ca.gov/Programs/CHSI/Pages/Vital-Records.aspx\">California Department of Public Health</a>.",
     "fr": "Les versions PDF sont disponibles sur le <a href=\"https://www.cdph.ca.gov/Programs/CHSI/Pages/Vital-Records.aspx\">Département de la santé publique de Californie</a>.",
     "es": "Las versiones en PDF están disponibles en el <a href=\"https://www.cdph.ca.gov/Programs/CHSI/Pages/Vital-Records.aspx\">Departamento de Salud Pública de California</a>.",
@@ -494,7 +457,6 @@
   },
   "vital_records_fill_notarize_mail": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/vital-records-shared.html",
     "en": "Fill it out, notarize it, and mail it according to the instructions.",
     "fr": "Remplissez-le, le notarisez et envoyez-le selon les instructions.",
     "es": "Llénela, llévela a notarizar y envíela por correo según las instrucciones.",

--- a/src/_data/i18n/i18n-volunteer.json
+++ b/src/_data/i18n/i18n-volunteer.json
@@ -1,7 +1,6 @@
 {
   "vol_title": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/volunteer-shared.html",
     "en": "Volunteer",
     "fr": "Volontaire",
     "es": "Ser voluntario",
@@ -14,7 +13,6 @@
   },
   "vol_description": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/volunteer-shared.html",
     "en": "Thank you for donating your time or money. When deciding how to help, rely on trusted sources and beware of scams.",
     "fr": "Merci pour votre don de temps ou d'argent. Lorsque vous décidez comment aider, reliez-vous à des sources fiables et restez attentif aux escroqueries.",
     "es": "Gracias por donar su tiempo o dinero. A la hora de decidir cómo ayudar, debe basarse en fuentes de confianza y cuidarse de las estafas.",
@@ -28,7 +26,6 @@
   "vol_keywords": {
     "status": "ap_review",
     "comment": "Machine translation",
-    "src_file": "pages/lafires/volunteer-shared.html",
     "en": "LA, Los Angeles, fires, wildfires",
     "fr": "LA, Los Angeles, incendies, incendies de forêt",
     "es": "LA, Los Angeles, incendios, incendios forestales",
@@ -41,7 +38,6 @@
   },
   "vol_lead_text": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/volunteer-shared.html",
     "en": "Thank you for donating your time or money. When deciding how to help, rely on trusted sources and beware of scams.",
     "fr": "Merci pour votre don de temps ou d'argent. Lorsque vous décidez comment aider, reliez-vous à des sources fiables et restez attentif aux escroqueries.",
     "es": "Gracias por donar su tiempo o dinero. A la hora de decidir cómo ayudar, debe basarse en fuentes de confianza y cuidarse de las estafas.",
@@ -54,7 +50,6 @@
   },
   "vol_on_this_page": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/volunteer-shared.html",
     "en": "On this page",
     "fr": "Sur cette page",
     "es": "En esta página",
@@ -67,7 +62,6 @@
   },
   "vol_where_to_volunteer_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/volunteer-shared.html",
     "en": "Where to volunteer",
     "fr": "Où volontaire",
     "es": "Dónde participar como voluntario",
@@ -80,7 +74,6 @@
   },
   "vol_aid_in_wildfire_recovery": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/volunteer-shared.html",
     "en": "Aid in wildfire recovery",
     "fr": "Aider à la récupération des incendies de forêt",
     "es": "Ayuda en la recuperación de incendios forestales",
@@ -93,7 +86,6 @@
   },
   "vol_by_california_volunteers": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/volunteer-shared.html",
     "en": "by California Volunteers",
     "fr": "par California Volunteers",
     "es": "de California Volunteers",
@@ -106,7 +98,6 @@
   },
   "vol_find_ways_to_get_involved": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/volunteer-shared.html",
     "en": "Find ways to get involved — in Los Angeles and throughout the state.",
     "fr": "Trouvez des façons de participer — à Los Angeles et dans tout l'état.",
     "es": "Encuentre maneras de involucrarse en Los Ángeles y en todo el estado.",
@@ -119,7 +110,6 @@
   },
   "vol_help_animals": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/volunteer-shared.html",
     "en": "Help animals",
     "fr": "Aider aux animaux",
     "es": "Ayuda de animales",
@@ -132,7 +122,6 @@
   },
   "vol_by_california_animal_response_emergency_support": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/volunteer-shared.html",
     "en": "by California Animal Response Emergency Support",
     "fr": "par California Animal Response Emergency Support",
     "es": "del Equipo de Respuesta ante Emergencias para Animales de California",
@@ -145,7 +134,6 @@
   },
   "vol_foster_or_adopt_a_pet": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/volunteer-shared.html",
     "en": "Foster or adopt a pet, volunteer, or donate pet food.",
     "fr": "Foster ou adopter un animal de compagnie, un volontaire ou faire un don de nourriture pour animaux.",
     "es": "Adopte una mascota, sea voluntario o done comida para mascotas.",
@@ -158,7 +146,6 @@
   },
   "vol_ways_to_donate_heading": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/volunteer-shared.html",
     "en": "Ways to donate",
     "fr": "Façons de donner",
     "es": "Formas de donar",
@@ -171,7 +158,6 @@
   },
   "vol_give_for_recovery": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/volunteer-shared.html",
     "en": "Give for recovery",
     "fr": "Donner pour la récupération",
     "es": "Donar para la recuperación",
@@ -184,7 +170,6 @@
   },
   "vol_by_philanthropy_california": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/volunteer-shared.html",
     "en": "by Philanthropy California",
     "fr": "par Philanthropy California",
     "es": "de Philanthropy California",
@@ -197,7 +182,6 @@
   },
   "vol_this_group_gathered_trusted_funds": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/volunteer-shared.html",
     "en": "This group gathered trusted funds for the 2025 disaster relief and recovery. They focus on helping marginalized or under-resourced communities.",
     "fr": "Ce groupe a réuni des fonds de confiance pour la récupération des dommages causés par les incendies de forêt en 2025. Ils se concentrent sur l'aide aux communautés marginalisées ou sous-régionales.",
     "es": "Este grupo reunió fondos de confianza para el alivio y la recuperación ante catástrofes de 2025. Se enfocan en ayudar a las comunidades sin recursos o de bajos recursos.",
@@ -210,7 +194,6 @@
   },
   "vol_give_for_animals": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/volunteer-shared.html",
     "en": "Give for animals",
     "fr": "Donner pour les animaux",
     "es": "Donar para animales",
@@ -223,7 +206,6 @@
   },
   "vol_donate_money_to_support_emergency_services_animals_need": {
     "status": "avantpage_delivery",
-    "src_file": "pages/lafires/volunteer-shared.html",
     "en": "Donate money to support emergency services animals need.",
     "fr": "Faire un don pour soutenir les animaux nécessitant des services d'urgence.",
     "es": "Donar dinero para apoyar los servicios de emergencia que los animales necesitan.",


### PR DESCRIPTION
Removed redundant src_file field from most i18n tables.  Left it in for i18n.json, which contains strings used in several different contexts.

Added a duplicate key checker for the translations loader, which checks for duplicate keys across all i18n files. There are no duplicate keys at the moment.