### PR TITLE
SEO - redirects lowercase

### DIFF
--- a/src/root/web.config
+++ b/src/root/web.config
@@ -38,11 +38,11 @@
         </rule>
         <rule name="Redirect -shared URLs" stopProcessing="true">
           <match url="(.*)-shared/$" />
-          <action type="Redirect" url="{R:1}/" redirectType="Permanent" />
+          <action type="Redirect" url="{ToLower:{R:1}}/" redirectType="Permanent" />
         </rule>
         <rule name="Redirect index.html to root" stopProcessing="true">
           <match url="(.*)/index.html$" />
-          <action type="Redirect" url="{R:1}/" redirectType="Permanent" />
+          <action type="Redirect" url="{ToLower:{R:1}}/" redirectType="Permanent" />
         </rule>
       </rules>
       <outboundRules>


### PR DESCRIPTION
handling the redirects with lowercase to prevent the folder name of "LAFires" from being applied to all redirects.