### PR TITLE
Removed defer from script with type module

### DIFF
--- a/src/_includes/head-js-css.html
+++ b/src/_includes/head-js-css.html
@@ -19,15 +19,9 @@
   defer
   crossorigin="anonymous"></script>
 
-<script
-  src="/lafires/js/lafires.min.js?v{% DateHex %}"
-  type="module"
-  defer></script>
+<script src="/lafires/js/lafires.min.js?v{% DateHex %}" type="module"></script>
 {%- if drc_map %}
-<script
-  src="/lafires/js/drc-map.min.js?dv{% DateHex %}"
-  type="module"
-  defer></script>
+<script src="/lafires/js/drc-map.min.js?dv{% DateHex %}" type="module"></script>
 {% endif -%}
 
 <!-- Site icons -->


### PR DESCRIPTION
If you are using type="module", you don't need to add the defer attribute because module scripts are automatically deferred.