### PR TITLE
rolling back redirect for plan-your-in-person-visit

### DIFF
--- a/src/root/web.config
+++ b/src/root/web.config
@@ -68,14 +68,6 @@
             redirectType="Permanent"
             appendQueryString="false" />
         </rule>
-        <rule name="Redirect plan-your-in-person-visit" stopProcessing="true">
-          <match url="^(.*?)/plan-your-in-person-visit/?$" />
-          <action
-            type="Redirect"
-            url="/{R:1}/help-for-you/get-help-in-person/plan-your-in-person-visit/"
-            redirectType="Permanent"
-            appendQueryString="false" />
-        </rule>
         <rule name="Redirect accessing-your-property" stopProcessing="true">
           <match url="^(.*?)/accessing-your-property/?$" />
           <action


### PR DESCRIPTION
can't do plan-your-in-person-visit as a blanket redirect because the result is in the match