### PR TITLE
SEO - adding single redirect rule for double slash url

### DIFF
--- a/src/root/web.config
+++ b/src/root/web.config
@@ -70,6 +70,10 @@
           <match url="(.*)/index.html$" />
           <action type="Redirect" url="{ToLower:{R:1}}/" redirectType="Permanent" />
         </rule>
+        <rule name="Redirect Specific Double Slash URL" stopProcessing="true">
+          <match url="^lafires//help-for-you/rebuild-your-house/$" />
+          <action type="Redirect" url="/lafires/help-for-you/rebuild-your-house/" redirectType="Permanent" />
+        </rule>
         <rule name="Redirect stay-healthy" stopProcessing="true">
           <match url="^(.*?)/stay-healthy/?$" />
           <action


### PR DESCRIPTION
lafires//help-for-you/rebuild-your-house/
-> (no double slash)
/lafires/help-for-you/rebuild-your-house/